### PR TITLE
Fix Quill editor not filling comment text area on web

### DIFF
--- a/src/components/comment-text-area.web.tsx
+++ b/src/components/comment-text-area.web.tsx
@@ -21,6 +21,28 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import ReactQuill from 'react-quill-new';
 import 'react-quill-new/dist/quill.snow.css';
 
+// Quill's snow theme sizes `.quill` to content (display:block, flex:0 1 auto)
+// so the editor never fills its parent RN View. Also the snow theme draws a
+// border on `.ql-container` that fights the outer View's border. Inject once
+// to make .quill/.ql-container flex-fill and drop the redundant border.
+// We target Quill globally because react-native-web's View strips className,
+// so we can't scope to a wrapper. The SDK renders at most one editor at a
+// time and Quill's classes are specific enough that collisions are unlikely.
+const quillFillStyleId = 'fc-rn-sdk-quill-fill';
+function ensureQuillFillStyles() {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(quillFillStyleId)) return;
+    const el = document.createElement('style');
+    el.id = quillFillStyleId;
+    el.textContent = `
+        .quill { display: flex; flex-direction: column; flex: 1; width: 100%; min-height: 0; }
+        .ql-container.ql-snow { border: 0; flex: 1; display: flex; flex-direction: column; font-size: inherit; font-family: inherit; min-height: 0; }
+        .ql-editor { flex: 1; padding: 8px; overflow: auto; }
+        .ql-editor.ql-blank::before { left: 8px; right: 8px; font-style: normal; color: #9a9a9a; }
+    `;
+    document.head.appendChild(el);
+}
+
 export interface ValueObserver {
     getValue?: () => string
 }
@@ -99,6 +121,7 @@ export function CommentTextArea({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const quillRef = useRef<any>(null);
     const [html, setHtml] = useState<string>(value || '');
+    useEffect(() => { ensureQuillFillStyles(); }, []);
     const [imageUploadProgress, setImageUploadProgress] = useState<number | null>(null);
     const [active, setActive] = useState<ActiveFormats>({ bold: false, italic: false, underline: false, strike: false, code: false });
 
@@ -223,16 +246,18 @@ export function CommentTextArea({
 
     return (
         <View style={{ width: '100%', flex: 1 }}>
-            <View style={[
-                styles.commentTextArea?.textarea,
-                {
-                    minHeight: useSingleLineCommentInput ? 40 : 100,
-                    borderRadius: styles.commentTextArea?.textarea?.borderRadius || 11,
-                    overflow: 'hidden',
-                    paddingHorizontal: 8,
-                    paddingVertical: 4,
-                }
-            ]}>
+            <View
+                style={[
+                    styles.commentTextArea?.textarea,
+                    {
+                        minHeight: useSingleLineCommentInput ? 40 : 100,
+                        borderRadius: styles.commentTextArea?.textarea?.borderRadius || 11,
+                        overflow: 'hidden',
+                        paddingHorizontal: 0,
+                        paddingVertical: 0,
+                    }
+                ]}
+            >
                 <ReactQuill
                     ref={quillRef}
                     theme="snow"
@@ -245,11 +270,6 @@ export function CommentTextArea({
                     onFocus={onFocus as any}
                     modules={quillModules}
                     formats={allowedFormats}
-                    style={{
-                        minHeight: useSingleLineCommentInput ? 32 : 92,
-                        height: '100%',
-                        backgroundColor: 'transparent',
-                    }}
                 />
             </View>
 


### PR DESCRIPTION
## Summary

The Quill editor mounted but only took ~44px of height (its content default), leaving the comment text area visually empty below it. The `.quill` root is `display:block; flex:0 1 auto` by default, and the snow theme border on `.ql-container` fought the outer RN View's border.

Injects global CSS once to make `.quill` + `.ql-container` flex-fill their parent, drops the redundant `.ql-container.ql-snow` border, and normalises `.ql-editor` padding to 8px. Rules target Quill globally (not scoped to a wrapper class) because react-native-web's `<View>` strips `className` - the SDK only ever renders one editor at a time so this is fine.

## Test plan

- [x] Playwright probe: `.ql-editor` rect matches outer View (870x100, editor 866x96 inside 2px borders)
- [x] Typed multi-line content renders at the top of the editor area with consistent padding