### PR TITLE
5.1.0: live chat streaming UX, online users, feed Android parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 5.1.0
+
+### New
+
+- **Live chat streaming UX**: `FastCommentsLiveChat` now matches the web live-chat widget. Compact Twitch-style rows (small avatar with the activity dot, bold name inlined with the message), periodic day separators, no per-message dates or per-message reply/vote bar, a red "Live" dot, and a divider above the composer. Ctrl/Cmd+Enter submits; the composer shimmers in place during a save instead of showing a spinner or flickering the text.
+- **Online users**: a red presence dot, an always-on count, and `OnlineUsersFacepile` + `OnlineUsersList` widgets. The list has Online/Offline sections (offline paginated via `getOfflineUsers`) and a `fill` mode for sidebar layouts. Presence is now applied **incrementally** from websocket frames (add/remove + a debounced `getUsersInfo` enrich) instead of re-fetching the whole list - matching the web widget.
+- **Feed parity with the Android SDK**:
+  - `FastCommentsFeedPostCreate` - a standalone post composer (Android `FeedPostCreateView` equivalent): author header, a rich enriched-editor body, media attachments, link attachments, tags (`tagSupplier`), custom toolbar buttons, and cancel/loading/error. Drive it from the feed's own store via `onStoreReady`, or pass it a `config`.
+  - Post rows gain author avatars, rich HTML content, a comment button that opens the post's comments (`urlId = "post:<id>"`, like Android), share, and a delete menu.
+  - Typed image layouts: single images render full-width at their aspect ratio; multiple render as a navigable carousel; link-only posts render action buttons.
+  - `config.hideFeedComposer` to suppress the built-in composer.
+- **Store access**: `FastCommentsLiveChat` / `FastCommentsLiveCommenting` / `FastCommentsFeed` accept `onStoreReady(store)`, and the `FastCommentsStore` type is exported, so hosts can render store-driven widgets (e.g. the online-users list) alongside a widget.
+- **Loaders**: every spinner is replaced with a shimmer (a sized `Skeleton` or a row-based `ListLoadingSkeleton`), all driven by one shared animation loop.
+- **Anchored popovers** (GIF picker, comment/sort/notification menus) now detect available space and flip above the trigger when there is no room below.
+
+### Fixed
+
+- Reliable scroll-to-bottom on live-chat load (pins the DOM scroller to its true max so the last message isn't clipped), and the per-message reply/vote toolbar no longer adds dead vertical space.
+- Submit buttons (reply, SSO login, edit save) share one filled style, and their icons follow the button text color instead of the page background.
+- The comment menu is a three-dot kebab in both modes.
+
 ## 5.0.1
 
 ### Fixed

--- a/example-web/README.md
+++ b/example-web/README.md
@@ -1,0 +1,32 @@
+# fastcomments-react-native-sdk - web example
+
+Runs the SDK in the browser via `react-native-web`.
+
+```bash
+npm install
+npm run dev      # http://localhost:5173
+npm run test     # vitest (web-lane tests)
+```
+
+## Component browser (default)
+
+Opening the dev server with no query params loads a **component browser** - a
+responsive, light/dark showcase of every drop-in widget, modeled on the
+`fastcomments-react` showcase. It is built entirely with React Native primitives
+(so it stays mobile/native-portable) and adapts between a desktop rail+stage
+layout and a mobile list+detail flow based on viewport width.
+
+- Widgets: **Live Commenting** (with GIF + image pickers, the notification bell,
+  and a live sort control), **Live Chat**, and **Social Feed**.
+- Every demo authenticates with **Simple SSO** (a plain user object, no signing)
+  so the composer posts as a known user and the bell/online-users appear.
+- The global light/dark toggle re-themes both the chrome and the live widget.
+
+Source lives under `src/showcase/`. Deep-link a screen with `?screen=live-commenting`
+(or `live-chat` / `feed`) and `?theme=dark`.
+
+## Legacy single-widget view
+
+Passing any of `?widget`, `?urlId`, or `?sort` renders a single widget instead of
+the browser (used by `screenshot.mjs` and quick manual checks). For example:
+`?urlId=native-test&widget=comments&theme=dark`.

--- a/example-web/index.html
+++ b/example-web/index.html
@@ -5,6 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FastComments React Native SDK - Web Example</title>
     <style>
+      /* Brand fonts (same families the React showcase uses) so the showcase
+         chrome's 'Manrope'/'Inter' fontFamily values resolve; falls back to
+         system-ui if they fail to load. */
+      @font-face {
+        font-family: "Manrope";
+        src: url("https://fastcomments.com/fonts/Manrope-VariableFont_wght.woff2") format("woff2");
+        font-weight: 200 800; font-display: swap;
+      }
+      @font-face {
+        font-family: "Inter";
+        src: url("https://fastcomments.com/fonts/Inter-VariableFont_slnt,wght.woff2") format("woff2");
+        font-weight: 100 900; font-display: swap;
+      }
       html, body, #root { height: 100%; margin: 0; padding: 0; }
       /* Make #root a flex container so react-native-web's AppContainer (flex: 1)
          resolves to the full viewport height instead of collapsing to content. */

--- a/example-web/src/main.tsx
+++ b/example-web/src/main.tsx
@@ -3,12 +3,14 @@ import { useState } from 'react';
 import { AppRegistry } from 'react-native';
 import { FastCommentsLiveCommenting, FastCommentsLiveChat, getDarkTheme } from '../../index';
 import type { FastCommentsCommentWidgetConfig } from 'fastcomments-typescript';
+import { Showcase } from './showcase/Showcase';
+import { findWidget } from './showcase/registry';
 
-// Browser equivalent of example/src/AppCommenting.tsx. Routes API calls
-// through the Vite dev proxy so localhost dev avoids CORS.
+// Legacy single-widget view (kept for screenshot.mjs and quick manual checks).
+// Routes API calls through the Vite dev proxy so localhost dev avoids CORS.
 // Query params: ?theme=dark renders the dark token set, ?widget=chat renders
 // the FastCommentsLiveChat preset widget, ?urlId= points at another page.
-function AppCommentingWeb() {
+function LegacyWidget() {
   const [config] = useState<FastCommentsCommentWidgetConfig>(() => {
     const search = new URLSearchParams(window.location.search);
     const sort = search.get('sort') as 'OF' | 'NF' | 'MR' | null;
@@ -18,33 +20,38 @@ function AppCommentingWeb() {
       showLiveRightAway: true,
       countAll: true,
       apiHost: '/_fc',
-      // Authenticate as a simple-SSO user (like our other tests/demos) so the
-      // composer posts as an identified user and the online-users facepile shows.
       simpleSSO: {
         username: 'Demo User',
         email: 'demo-user@fctest.com',
         avatar: 'https://i.pravatar.cc/200?u=fastcomments0',
       },
-      // ?sort=OF|NF|MR overrides the default sort. Only set it when present so we
-      // don't pass `defaultSortDirection: undefined`, which would clobber the
-      // chat preset's 'NF' and break live-chat detection.
       ...(sort ? { defaultSortDirection: sort } : {}),
     } as FastCommentsCommentWidgetConfig;
   });
 
   const params = new URLSearchParams(window.location.search);
   const theme = params.get('theme') === 'dark' ? getDarkTheme() : undefined;
-  // Default to the live chat widget for testing; ?widget=comments shows the
-  // threaded commenting widget.
   if (params.get('widget') === 'comments') {
     return <FastCommentsLiveCommenting config={config} theme={theme} />;
   }
   return <FastCommentsLiveChat config={config} theme={theme} />;
 }
 
+// Default entry: the component browser. When the legacy single-widget query
+// params are present (as screenshot.mjs always passes), fall back to LegacyWidget
+// so existing screenshots/manual flows keep working unchanged.
+function Root() {
+  const params = new URLSearchParams(window.location.search);
+  const isLegacy = params.has('widget') || params.has('urlId') || params.has('sort');
+  if (isLegacy) {
+    return <LegacyWidget />;
+  }
+  return <Showcase initialKey={findWidget(params.get('screen'))} initialMode={params.get('theme') === 'dark' ? 'dark' : 'light'} />;
+}
+
 const appName = 'FastcommentsReactNativeWebExample';
 
-AppRegistry.registerComponent(appName, () => AppCommentingWeb);
+AppRegistry.registerComponent(appName, () => Root);
 AppRegistry.runApplication(appName, {
   rootTag: document.getElementById('root'),
 });

--- a/example-web/src/showcase/Showcase.tsx
+++ b/example-web/src/showcase/Showcase.tsx
@@ -1,0 +1,57 @@
+import { useMemo, useState } from 'react';
+import { ScrollView, View, useWindowDimensions } from 'react-native';
+import { WIDGETS } from './registry';
+import type { WidgetKey } from './registry';
+import { getShellTheme } from './chrome/shell-theme';
+import type { ThemeMode } from './chrome/shell-theme';
+import { MobileTopBar, Rail } from './chrome/nav';
+import { HomeScreen } from './screens/HomeScreen';
+
+const WIDE_BREAKPOINT = 720;
+const RAIL_WIDTH = 300;
+
+export interface ShowcaseProps {
+    initialKey?: WidgetKey | 'home';
+    initialMode?: ThemeMode;
+}
+
+// Root of the component browser. Holds the two pieces of app state (which widget,
+// which theme) and renders a desktop rail+stage or a mobile list+detail flow
+// depending on viewport width. The global theme drives both the chrome and the
+// SDK widget shown on screen.
+export function Showcase({ initialKey, initialMode }: ShowcaseProps) {
+    const [selected, setSelected] = useState<WidgetKey | 'home'>(initialKey ?? 'home');
+    const [mode, setMode] = useState<ThemeMode>(initialMode ?? 'light');
+    const { width, height } = useWindowDimensions();
+    const wide = width >= WIDE_BREAKPOINT;
+    const shell = useMemo(() => getShellTheme(mode), [mode]);
+
+    const current = WIDGETS.find((w) => w.key === selected);
+    const panelHeight = wide ? 640 : Math.max(440, height - 260);
+
+    const stage = (
+        <ScrollView style={{ flex: 1, backgroundColor: shell.bg }} contentContainerStyle={{ padding: wide ? 40 : 18, paddingBottom: 120 }}>
+            {current ? (
+                <current.Screen mode={mode} shell={shell} panelHeight={panelHeight} />
+            ) : (
+                <HomeScreen shell={shell} widgets={WIDGETS} onSelect={setSelected} mode={mode} onToggleMode={setMode} compact={!wide} />
+            )}
+        </ScrollView>
+    );
+
+    if (wide) {
+        return (
+            <View style={{ flex: 1, flexDirection: 'row', backgroundColor: shell.bg }}>
+                <Rail shell={shell} widgets={WIDGETS} selected={selected} onSelect={setSelected} mode={mode} onToggleMode={setMode} width={RAIL_WIDTH} />
+                {stage}
+            </View>
+        );
+    }
+
+    return (
+        <View style={{ flex: 1, backgroundColor: shell.bg }}>
+            {current ? <MobileTopBar shell={shell} title={current.label} onBack={() => setSelected('home')} mode={mode} onToggleMode={setMode} /> : null}
+            {stage}
+        </View>
+    );
+}

--- a/example-web/src/showcase/chrome/DemoChrome.tsx
+++ b/example-web/src/showcase/chrome/DemoChrome.tsx
@@ -16,6 +16,8 @@ export interface DemoChromeProps {
     tags?: DemoTag[];
     /** Height of the live-widget panel (the widget renders its own scroll inside). */
     panelHeight: number;
+    /** Optional fixed panel width (centered). Defaults to full content width. */
+    panelWidth?: number;
     code?: string;
     codeLabel?: string;
     children: ReactNode;
@@ -23,7 +25,7 @@ export interface DemoChromeProps {
 
 // Equivalent of the React showcase's _DemoChrome: breadcrumb + title + subtitle +
 // tags, a bordered panel holding the live widget, and a copy-paste code block.
-export function DemoChrome({ shell, breadcrumb, title, subtitle, tags, panelHeight, code, codeLabel, children }: DemoChromeProps) {
+export function DemoChrome({ shell, breadcrumb, title, subtitle, tags, panelHeight, panelWidth, code, codeLabel, children }: DemoChromeProps) {
     return (
         <View style={{ gap: 24 }}>
             <View style={{ borderBottomWidth: 1, borderBottomColor: shell.border, paddingBottom: 18, gap: 8 }}>
@@ -70,6 +72,9 @@ export function DemoChrome({ shell, breadcrumb, title, subtitle, tags, panelHeig
             <View
                 style={{
                     height: panelHeight,
+                    width: panelWidth ?? '100%',
+                    maxWidth: '100%',
+                    alignSelf: panelWidth ? 'center' : 'stretch',
                     borderWidth: 1,
                     borderColor: shell.border,
                     borderRadius: 18,

--- a/example-web/src/showcase/chrome/DemoChrome.tsx
+++ b/example-web/src/showcase/chrome/DemoChrome.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import { Platform, Pressable, ScrollView, Text, View } from 'react-native';
+import type { ShellTheme } from './shell-theme';
+
+export interface DemoTag {
+    label: string;
+    brand?: boolean;
+}
+
+export interface DemoChromeProps {
+    shell: ShellTheme;
+    breadcrumb: string;
+    title: string;
+    subtitle: string;
+    tags?: DemoTag[];
+    /** Height of the live-widget panel (the widget renders its own scroll inside). */
+    panelHeight: number;
+    code?: string;
+    codeLabel?: string;
+    children: ReactNode;
+}
+
+// Equivalent of the React showcase's _DemoChrome: breadcrumb + title + subtitle +
+// tags, a bordered panel holding the live widget, and a copy-paste code block.
+export function DemoChrome({ shell, breadcrumb, title, subtitle, tags, panelHeight, code, codeLabel, children }: DemoChromeProps) {
+    return (
+        <View style={{ gap: 24 }}>
+            <View style={{ borderBottomWidth: 1, borderBottomColor: shell.border, paddingBottom: 18, gap: 8 }}>
+                <Text style={{ fontFamily: shell.mono, fontSize: 11, letterSpacing: 2, textTransform: 'uppercase', color: shell.inkMute }}>
+                    {breadcrumb}
+                </Text>
+                <Text style={{ fontFamily: shell.display, fontWeight: '700', fontSize: 28, letterSpacing: -0.5, color: shell.ink }}>
+                    {title}
+                </Text>
+                <Text style={{ fontFamily: shell.body, color: shell.inkDim, fontSize: 15, lineHeight: 23, maxWidth: 660 }}>
+                    {subtitle}
+                </Text>
+                {tags && tags.length > 0 ? (
+                    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 6 }}>
+                        {tags.map((t) => (
+                            <View
+                                key={t.label}
+                                style={{
+                                    paddingVertical: 6,
+                                    paddingHorizontal: 11,
+                                    borderRadius: 999,
+                                    borderWidth: 1,
+                                    borderColor: t.brand ? shell.accentB : shell.borderStrong,
+                                    backgroundColor: t.brand ? 'rgba(132,83,237,0.16)' : shell.subtle,
+                                }}
+                            >
+                                <Text
+                                    style={{
+                                        fontFamily: shell.mono,
+                                        fontSize: 10.5,
+                                        letterSpacing: 1.6,
+                                        textTransform: 'uppercase',
+                                        color: t.brand ? shell.accentB : shell.inkDim,
+                                    }}
+                                >
+                                    {t.label}
+                                </Text>
+                            </View>
+                        ))}
+                    </View>
+                ) : null}
+            </View>
+
+            <View
+                style={{
+                    height: panelHeight,
+                    borderWidth: 1,
+                    borderColor: shell.border,
+                    borderRadius: 18,
+                    overflow: 'hidden',
+                    backgroundColor: shell.panel,
+                }}
+            >
+                {children}
+            </View>
+
+            {code ? <CodePanel shell={shell} code={code} label={codeLabel} /> : null}
+        </View>
+    );
+}
+
+function CodePanel({ shell, code, label }: { shell: ShellTheme; code: string; label?: string }) {
+    const [copied, setCopied] = useState(false);
+
+    const copy = () => {
+        if (Platform.OS === 'web' && typeof navigator !== 'undefined' && navigator.clipboard) {
+            navigator.clipboard
+                .writeText(code)
+                .then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1200);
+                })
+                .catch(() => {});
+        }
+    };
+
+    return (
+        <View style={{ borderWidth: 1, borderColor: shell.border, borderRadius: 18, overflow: 'hidden', backgroundColor: shell.panel }}>
+            <View
+                style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    paddingVertical: 12,
+                    paddingHorizontal: 18,
+                    borderBottomWidth: 1,
+                    borderBottomColor: shell.border,
+                }}
+            >
+                <Text style={{ fontFamily: shell.mono, fontSize: 10.5, letterSpacing: 2, textTransform: 'uppercase', color: shell.inkMute }}>
+                    {label ?? 'App.tsx'}
+                </Text>
+                {Platform.OS === 'web' ? (
+                    <Pressable
+                        onPress={copy}
+                        style={{ borderWidth: 1, borderColor: shell.borderStrong, borderRadius: 999, paddingVertical: 5, paddingHorizontal: 11 }}
+                    >
+                        <Text style={{ fontFamily: shell.mono, fontSize: 10.5, letterSpacing: 1.6, textTransform: 'uppercase', color: shell.inkDim }}>
+                            {copied ? 'Copied' : 'Copy'}
+                        </Text>
+                    </Pressable>
+                ) : null}
+            </View>
+            <ScrollView horizontal style={{ backgroundColor: shell.codeBg }} contentContainerStyle={{ padding: 18 }}>
+                <Text style={{ fontFamily: shell.mono, fontSize: 12.5, lineHeight: 21, color: shell.ink }}>{code}</Text>
+            </ScrollView>
+        </View>
+    );
+}

--- a/example-web/src/showcase/chrome/nav.tsx
+++ b/example-web/src/showcase/chrome/nav.tsx
@@ -1,0 +1,128 @@
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import type { ShellTheme, ThemeMode } from './shell-theme';
+import type { ShowcaseEntry, WidgetKey } from '../registry';
+
+export function ThemeToggle({ shell, mode, onChange }: { shell: ShellTheme; mode: ThemeMode; onChange: (m: ThemeMode) => void }) {
+    return (
+        <View
+            style={{
+                flexDirection: 'row',
+                borderWidth: 1,
+                borderColor: shell.borderStrong,
+                borderRadius: 999,
+                padding: 3,
+                alignSelf: 'flex-start',
+                backgroundColor: shell.subtle,
+            }}
+        >
+            {(['light', 'dark'] as ThemeMode[]).map((m) => {
+                const active = m === mode;
+                return (
+                    <Pressable
+                        key={m}
+                        onPress={() => onChange(m)}
+                        style={{ paddingVertical: 6, paddingHorizontal: 14, borderRadius: 999, backgroundColor: active ? shell.accentA : 'transparent' }}
+                    >
+                        <Text style={{ fontFamily: shell.mono, fontSize: 10.5, letterSpacing: 2, textTransform: 'uppercase', color: active ? '#ffffff' : shell.inkMute }}>
+                            {m}
+                        </Text>
+                    </Pressable>
+                );
+            })}
+        </View>
+    );
+}
+
+function NavItem({ shell, entry, active, onPress }: { shell: ShellTheme; entry: ShowcaseEntry; active: boolean; onPress: () => void }) {
+    return (
+        <Pressable
+            onPress={onPress}
+            style={{
+                paddingVertical: 10,
+                paddingHorizontal: 12,
+                borderRadius: 10,
+                borderWidth: 1,
+                borderColor: active ? shell.accentB : 'transparent',
+                backgroundColor: active ? shell.railTint : 'transparent',
+                gap: 4,
+            }}
+        >
+            <Text style={{ fontFamily: shell.display, fontWeight: '600', fontSize: 14, color: shell.ink }}>{entry.label}</Text>
+            <Text style={{ fontFamily: shell.body, fontSize: 12, color: shell.inkMute }}>{entry.hint}</Text>
+        </Pressable>
+    );
+}
+
+interface RailProps {
+    shell: ShellTheme;
+    widgets: ShowcaseEntry[];
+    selected: WidgetKey | 'home';
+    onSelect: (key: WidgetKey | 'home') => void;
+    mode: ThemeMode;
+    onToggleMode: (m: ThemeMode) => void;
+    width: number;
+}
+
+export function Rail({ shell, widgets, selected, onSelect, mode, onToggleMode, width }: RailProps) {
+    return (
+        <View style={{ width, borderRightWidth: 1, borderRightColor: shell.border, backgroundColor: shell.panel }}>
+            <View style={{ flex: 1, padding: 22, gap: 22 }}>
+                <Pressable onPress={() => onSelect('home')} style={{ gap: 3 }}>
+                    <Text style={{ fontFamily: shell.display, fontWeight: '700', fontSize: 17, letterSpacing: -0.3, color: shell.ink }}>FastComments</Text>
+                    <Text style={{ fontFamily: shell.mono, fontSize: 10, letterSpacing: 3, textTransform: 'uppercase', color: shell.inkMute }}>
+                        react native · showcase
+                    </Text>
+                </Pressable>
+
+                <ScrollView style={{ flex: 1 }} contentContainerStyle={{ gap: 6 }}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, paddingHorizontal: 10, paddingBottom: 4 }}>
+                        <Text style={{ fontFamily: shell.mono, fontSize: 10.5, letterSpacing: 2, color: shell.accentC }}>01</Text>
+                        <Text style={{ fontFamily: shell.mono, fontSize: 10.5, letterSpacing: 2, textTransform: 'uppercase', color: shell.inkDim }}>Widgets</Text>
+                    </View>
+                    {widgets.map((entry) => (
+                        <NavItem key={entry.key} shell={shell} entry={entry} active={selected === entry.key} onPress={() => onSelect(entry.key)} />
+                    ))}
+                </ScrollView>
+
+                <View style={{ gap: 12, paddingTop: 14, borderTopWidth: 1, borderTopColor: shell.border }}>
+                    <ThemeToggle shell={shell} mode={mode} onChange={onToggleMode} />
+                    <View style={{ alignSelf: 'flex-start', borderWidth: 1, borderColor: shell.border, borderRadius: 6, backgroundColor: shell.subtle, paddingVertical: 6, paddingHorizontal: 9 }}>
+                        <Text style={{ fontFamily: shell.mono, fontSize: 11.5, color: shell.inkDim }}>npm i fastcomments-react-native-sdk</Text>
+                    </View>
+                    <Text style={{ fontFamily: shell.body, fontSize: 11.5, color: shell.inkMute }}>fastcomments.com</Text>
+                </View>
+            </View>
+        </View>
+    );
+}
+
+interface MobileTopBarProps {
+    shell: ShellTheme;
+    title: string;
+    onBack: () => void;
+    mode: ThemeMode;
+    onToggleMode: (m: ThemeMode) => void;
+}
+
+export function MobileTopBar({ shell, title, onBack, mode, onToggleMode }: MobileTopBarProps) {
+    return (
+        <View
+            style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingVertical: 12,
+                paddingHorizontal: 16,
+                borderBottomWidth: 1,
+                borderBottomColor: shell.border,
+                backgroundColor: shell.panel,
+            }}
+        >
+            <Pressable onPress={onBack} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ fontFamily: shell.display, fontSize: 16, color: shell.accentB }}>{'←'}</Text>
+                <Text style={{ fontFamily: shell.display, fontWeight: '700', fontSize: 16, color: shell.ink }}>{title}</Text>
+            </Pressable>
+            <ThemeToggle shell={shell} mode={mode} onChange={onToggleMode} />
+        </View>
+    );
+}

--- a/example-web/src/showcase/chrome/shell-theme.ts
+++ b/example-web/src/showcase/chrome/shell-theme.ts
@@ -1,0 +1,75 @@
+// Visual tokens for the showcase chrome (rail, cards, code panels) - separate
+// from the SDK widget theme. Ported from the React showcase's index.css so the
+// two demos look like siblings. Web-only stacks (this app runs on react-native-web).
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface ShellTheme {
+    mode: ThemeMode;
+    bg: string;
+    panel: string;
+    panelRaised: string;
+    border: string;
+    borderStrong: string;
+    ink: string;
+    inkDim: string;
+    inkMute: string;
+    accentA: string;
+    accentB: string;
+    accentC: string;
+    railTint: string;
+    subtle: string;
+    codeBg: string;
+    display: string;
+    body: string;
+    mono: string;
+}
+
+const FONT_DISPLAY = 'Manrope, system-ui, -apple-system, sans-serif';
+const FONT_BODY = 'Inter, system-ui, -apple-system, sans-serif';
+const FONT_MONO = 'ui-monospace, Menlo, Consolas, monospace';
+
+export function getShellTheme(mode: ThemeMode): ShellTheme {
+    if (mode === 'dark') {
+        return {
+            mode,
+            bg: '#030303',
+            panel: '#0d0d0d',
+            panelRaised: '#121212',
+            border: '#1f1f22',
+            borderStrong: '#2a2a2f',
+            ink: '#fcfcfc',
+            inkDim: '#a6a6a6',
+            inkMute: '#686868',
+            accentA: '#5356ec',
+            accentB: '#8453ed',
+            accentC: '#53b7ee',
+            railTint: 'rgba(83,86,236,0.22)',
+            subtle: 'rgba(255,255,255,0.04)',
+            codeBg: '#030303',
+            display: FONT_DISPLAY,
+            body: FONT_BODY,
+            mono: FONT_MONO,
+        };
+    }
+    return {
+        mode,
+        bg: '#f7f7f8',
+        panel: '#ffffff',
+        panelRaised: '#f1f1f4',
+        border: '#e4e4e7',
+        borderStrong: '#d4d4d8',
+        ink: '#0b0b0f',
+        inkDim: '#4a4a52',
+        inkMute: '#8a8a93',
+        accentA: '#5356ec',
+        accentB: '#8453ed',
+        accentC: '#53b7ee',
+        railTint: 'rgba(83,86,236,0.10)',
+        subtle: 'rgba(0,0,0,0.04)',
+        codeBg: '#f7f7f8',
+        display: FONT_DISPLAY,
+        body: FONT_BODY,
+        mono: FONT_MONO,
+    };
+}

--- a/example-web/src/showcase/demo-config.ts
+++ b/example-web/src/showcase/demo-config.ts
@@ -1,0 +1,32 @@
+import { Platform } from 'react-native';
+import type { FastCommentsRNConfig } from './sdk';
+
+// Every widget demo authenticates as this Simple SSO user, so the composer posts
+// as a known identity and the notification bell / online-users facepile appear.
+// Simple SSO needs no server signing - just a user object on the config.
+export const DEMO_SIMPLE_SSO = {
+    username: 'Demo User',
+    email: 'demo-user@fctest.com',
+    avatar: 'https://i.pravatar.cc/200?u=fastcomments0',
+};
+
+// Seeded thread (also used by screenshot.mjs) so the commenting demo shows real
+// content out of the box. Chat and feed get their own pages so their very
+// different message shapes don't bleed into each other.
+export const SHOWCASE_URL_ID = 'fastcomments-rn-showcase-v3';
+export const CHAT_URL_ID = 'fastcomments-rn-showcase-chat';
+export const FEED_URL_ID = 'fastcomments-rn-showcase-feed';
+
+export function buildConfig(urlId: string, overrides?: Partial<FastCommentsRNConfig>): FastCommentsRNConfig {
+    return {
+        tenantId: 'demo',
+        urlId,
+        showLiveRightAway: true,
+        countAll: true,
+        // In the browser, route through the Vite dev proxy ('/_fc' -> fastcomments.com)
+        // to avoid CORS. Native builds talk to the host directly.
+        ...(Platform.OS === 'web' ? { apiHost: '/_fc' } : {}),
+        simpleSSO: DEMO_SIMPLE_SSO,
+        ...overrides,
+    };
+}

--- a/example-web/src/showcase/registry.tsx
+++ b/example-web/src/showcase/registry.tsx
@@ -1,0 +1,45 @@
+import type { ComponentType } from 'react';
+import type { ScreenProps } from './types';
+import { LiveCommentingScreen } from './screens/LiveCommentingScreen';
+import { LiveChatScreen } from './screens/LiveChatScreen';
+import { FeedScreen } from './screens/FeedScreen';
+
+export type WidgetKey = 'live-commenting' | 'live-chat' | 'feed';
+
+export interface ShowcaseEntry {
+    key: WidgetKey;
+    label: string;
+    hint: string;
+    kind: string;
+    Screen: ComponentType<ScreenProps>;
+}
+
+// Drives both the rail nav and the home grid. Order = display order.
+export const WIDGETS: ShowcaseEntry[] = [
+    {
+        key: 'live-commenting',
+        label: 'Live Commenting',
+        hint: 'Threaded comments with GIFs, image attachments, and a notification bell',
+        kind: 'widget',
+        Screen: LiveCommentingScreen,
+    },
+    {
+        key: 'live-chat',
+        label: 'Live Chat',
+        hint: 'Realtime flat chat stream with a live online-user header',
+        kind: 'widget',
+        Screen: LiveChatScreen,
+    },
+    {
+        key: 'feed',
+        label: 'Social Feed',
+        hint: 'Posts, media uploads, and emoji reactions',
+        kind: 'widget',
+        Screen: FeedScreen,
+    },
+];
+
+export function findWidget(key: string | null | undefined): WidgetKey | 'home' {
+    const entry = WIDGETS.find((w) => w.key === key);
+    return entry ? entry.key : 'home';
+}

--- a/example-web/src/showcase/screens/FeedScreen.tsx
+++ b/example-web/src/showcase/screens/FeedScreen.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { FastCommentsFeed, getDarkTheme, getLightTheme } from '../sdk';
+import { DemoChrome } from '../chrome/DemoChrome';
+import { buildConfig, FEED_URL_ID } from '../demo-config';
+import type { ScreenProps } from '../types';
+
+const CODE = `import { FastCommentsFeed } from 'fastcomments-react-native-sdk';
+
+const config = {
+  tenantId: 'demo',
+  urlId: 'your-feed-id',
+  simpleSSO: {
+    username: 'Demo User',
+    email: 'demo-user@fctest.com',
+    avatar: 'https://i.pravatar.cc/200?u=fastcomments0',
+  },
+};
+
+<FastCommentsFeed config={config} />;`;
+
+export function FeedScreen({ mode, shell, panelHeight }: ScreenProps) {
+    const theme = mode === 'dark' ? getDarkTheme() : getLightTheme();
+    const config = useMemo(() => buildConfig(FEED_URL_ID), []);
+
+    return (
+        <DemoChrome
+            shell={shell}
+            breadcrumb="Widgets / Social Feed"
+            title="Social Feed"
+            subtitle="A social timeline: a post composer with media upload, emoji reactions, follow pills, and a 'new posts' banner. Posts here are authored by the Simple SSO demo user."
+            tags={[{ label: 'demo tenant' }, { label: 'simple sso', brand: true }, { label: 'posts · reactions' }]}
+            panelHeight={panelHeight}
+            code={CODE}
+            codeLabel="FeedScreen.tsx"
+        >
+            <FastCommentsFeed key={mode} config={config} theme={theme} />
+        </DemoChrome>
+    );
+}

--- a/example-web/src/showcase/screens/FeedScreen.tsx
+++ b/example-web/src/showcase/screens/FeedScreen.tsx
@@ -35,7 +35,7 @@ const [store, setStore] = useState(null);
   <FastCommentsFeed config={config} onStoreReady={(s) => setStore(() => s)} />
 </View>;`;
 
-export function FeedScreen({ mode, shell, panelHeight }: ScreenProps) {
+export function FeedScreen({ mode, shell }: ScreenProps) {
     const theme = mode === 'dark' ? getDarkTheme() : getLightTheme();
     // Hide the built-in composer; we place a standalone one above the feed,
     // driven by the feed's own store (so new posts appear instantly).
@@ -49,7 +49,8 @@ export function FeedScreen({ mode, shell, panelHeight }: ScreenProps) {
             title="Social Feed"
             subtitle="A standalone post composer (rich text, media, links, tags, custom toolbar buttons) driven by the feed's own live store, plus posts with avatars, typed image layouts, reactions, comments, and share. Mirrors the Android SDK's separate FeedPostCreateView + FastCommentsFeedView."
             tags={[{ label: 'demo tenant' }, { label: 'simple sso', brand: true }, { label: 'standalone composer' }]}
-            panelHeight={panelHeight}
+            panelHeight={800}
+            panelWidth={500}
             code={CODE}
             codeLabel="FeedScreen.tsx"
         >

--- a/example-web/src/showcase/screens/FeedScreen.tsx
+++ b/example-web/src/showcase/screens/FeedScreen.tsx
@@ -1,39 +1,75 @@
-import { useMemo } from 'react';
-import { FastCommentsFeed, getDarkTheme, getLightTheme } from '../sdk';
+import { useMemo, useState } from 'react';
+import { View } from 'react-native';
+import { FastCommentsFeed, FastCommentsFeedPostCreate, getDarkTheme, getLightTheme } from '../sdk';
+import type { FastCommentsStore } from '../sdk';
 import { DemoChrome } from '../chrome/DemoChrome';
 import { buildConfig, FEED_URL_ID } from '../demo-config';
 import type { ScreenProps } from '../types';
 
-const CODE = `import { FastCommentsFeed } from 'fastcomments-react-native-sdk';
+const CODE = `import { FastCommentsFeed, FastCommentsFeedPostCreate } from 'fastcomments-react-native-sdk';
 
 const config = {
   tenantId: 'demo',
   urlId: 'your-feed-id',
-  simpleSSO: {
-    username: 'Demo User',
-    email: 'demo-user@fctest.com',
-    avatar: 'https://i.pravatar.cc/200?u=fastcomments0',
-  },
+  hideFeedComposer: true, // we render the composer ourselves, above the feed
+  simpleSSO: { username: 'Demo User', email: 'demo-user@fctest.com' },
 };
 
-<FastCommentsFeed config={config} />;`;
+// Grab the feed's live store and drive a standalone composer from it - new
+// posts appear instantly (same store). Mirrors Android's separate
+// FeedPostCreateView + FastCommentsFeedView.
+const [store, setStore] = useState(null);
+
+<View style={{ flex: 1 }}>
+  {store && (
+    <FastCommentsFeedPostCreate
+      store={store}
+      tagSupplier={() => ['showcase']}
+      toolbarButtons={[{
+        id: 'demo-image',
+        label: '🖼 Demo image',
+        onPress: (api) => api.addMedia('https://picsum.photos/seed/' + Date.now() + '/600/400'),
+      }]}
+    />
+  )}
+  <FastCommentsFeed config={config} onStoreReady={(s) => setStore(() => s)} />
+</View>;`;
 
 export function FeedScreen({ mode, shell, panelHeight }: ScreenProps) {
     const theme = mode === 'dark' ? getDarkTheme() : getLightTheme();
-    const config = useMemo(() => buildConfig(FEED_URL_ID), []);
+    // Hide the built-in composer; we place a standalone one above the feed,
+    // driven by the feed's own store (so new posts appear instantly).
+    const config = useMemo(() => buildConfig(FEED_URL_ID, { hideFeedComposer: true }), []);
+    const [store, setStore] = useState<FastCommentsStore | null>(null);
 
     return (
         <DemoChrome
             shell={shell}
             breadcrumb="Widgets / Social Feed"
             title="Social Feed"
-            subtitle="A social timeline: a post composer with media upload, emoji reactions, follow pills, and a 'new posts' banner. Posts here are authored by the Simple SSO demo user."
-            tags={[{ label: 'demo tenant' }, { label: 'simple sso', brand: true }, { label: 'posts · reactions' }]}
+            subtitle="A standalone post composer (rich text, media, links, tags, custom toolbar buttons) driven by the feed's own live store, plus posts with avatars, typed image layouts, reactions, comments, and share. Mirrors the Android SDK's separate FeedPostCreateView + FastCommentsFeedView."
+            tags={[{ label: 'demo tenant' }, { label: 'simple sso', brand: true }, { label: 'standalone composer' }]}
             panelHeight={panelHeight}
             code={CODE}
             codeLabel="FeedScreen.tsx"
         >
-            <FastCommentsFeed key={mode} config={config} theme={theme} />
+            <View style={{ flex: 1 }}>
+                {store ? (
+                    <FastCommentsFeedPostCreate
+                        store={store}
+                        theme={theme}
+                        tagSupplier={() => ['showcase']}
+                        toolbarButtons={[
+                            {
+                                id: 'demo-image',
+                                label: '🖼 Demo image',
+                                onPress: (api) => api.addMedia(`https://picsum.photos/seed/${Date.now()}/600/400`),
+                            },
+                        ]}
+                    />
+                ) : null}
+                <FastCommentsFeed key={mode} config={config} theme={theme} onStoreReady={(s) => setStore(() => s)} />
+            </View>
         </DemoChrome>
     );
 }

--- a/example-web/src/showcase/screens/HomeScreen.tsx
+++ b/example-web/src/showcase/screens/HomeScreen.tsx
@@ -1,0 +1,76 @@
+import { Pressable, Text, View } from 'react-native';
+import type { ShellTheme, ThemeMode } from '../chrome/shell-theme';
+import { ThemeToggle } from '../chrome/nav';
+import type { ShowcaseEntry, WidgetKey } from '../registry';
+
+interface HomeScreenProps {
+    shell: ShellTheme;
+    widgets: ShowcaseEntry[];
+    onSelect: (key: WidgetKey) => void;
+    mode: ThemeMode;
+    onToggleMode: (m: ThemeMode) => void;
+    compact: boolean;
+}
+
+export function HomeScreen({ shell, widgets, onSelect, mode, onToggleMode, compact }: HomeScreenProps) {
+    return (
+        <View style={{ gap: 28 }}>
+            <View style={{ gap: 18 }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
+                    <Text style={{ fontFamily: shell.mono, fontSize: 11, letterSpacing: 3, textTransform: 'uppercase', color: shell.inkMute }}>
+                        fastcomments / react native · showcase
+                    </Text>
+                    {compact ? <ThemeToggle shell={shell} mode={mode} onChange={onToggleMode} /> : null}
+                </View>
+                <Text style={{ fontFamily: shell.display, fontWeight: '800', fontSize: compact ? 38 : 52, lineHeight: compact ? 42 : 56, letterSpacing: -1.5, color: shell.ink }}>
+                    Comment infrastructure{'\n'}
+                    <Text style={{ color: shell.accentB }}>for React Native.</Text>
+                </Text>
+                <Text style={{ fontFamily: shell.body, fontSize: 16, lineHeight: 26, color: shell.inkDim, maxWidth: 640 }}>
+                    Every drop-in widget the SDK ships, running live against the public demo tenant and signed in with Simple SSO.
+                    Tap a widget to see it working, copy the code, and lift it straight into your app.
+                </Text>
+            </View>
+
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 14 }}>
+                <Text style={{ fontFamily: shell.mono, fontSize: 11, letterSpacing: 2, color: shell.inkMute }}>01</Text>
+                <Text style={{ fontFamily: shell.display, fontWeight: '700', fontSize: 20, color: shell.ink }}>Widgets</Text>
+                <View style={{ flex: 1, height: 1, backgroundColor: shell.border }} />
+                <Text style={{ fontFamily: shell.mono, fontSize: 11, letterSpacing: 1.6, textTransform: 'uppercase', color: shell.inkMute }}>
+                    {widgets.length} components
+                </Text>
+            </View>
+
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 14 }}>
+                {widgets.map((entry) => (
+                    <Pressable
+                        key={entry.key}
+                        onPress={() => onSelect(entry.key)}
+                        style={{
+                            flexGrow: 1,
+                            flexBasis: compact ? '100%' : 260,
+                            minWidth: compact ? undefined : 260,
+                            borderWidth: 1,
+                            borderColor: shell.border,
+                            borderRadius: 16,
+                            backgroundColor: shell.panel,
+                            padding: 22,
+                            gap: 10,
+                        }}
+                    >
+                        <Text style={{ fontFamily: shell.mono, fontSize: 10, letterSpacing: 2, textTransform: 'uppercase', color: shell.accentC }}>
+                            {entry.kind}
+                        </Text>
+                        <Text style={{ fontFamily: shell.display, fontWeight: '700', fontSize: 19, letterSpacing: -0.4, color: shell.ink }}>
+                            {entry.label}
+                        </Text>
+                        <Text style={{ fontFamily: shell.body, fontSize: 13.5, lineHeight: 20, color: shell.inkDim }}>{entry.hint}</Text>
+                        <Text style={{ fontFamily: shell.mono, fontSize: 11, letterSpacing: 1.4, textTransform: 'uppercase', color: shell.inkMute, marginTop: 4 }}>
+                            Open example →
+                        </Text>
+                    </Pressable>
+                ))}
+            </View>
+        </View>
+    );
+}

--- a/example-web/src/showcase/screens/LiveChatScreen.tsx
+++ b/example-web/src/showcase/screens/LiveChatScreen.tsx
@@ -1,0 +1,73 @@
+import { useMemo, useState } from 'react';
+import { View, useWindowDimensions } from 'react-native';
+import { FastCommentsLiveChat, OnlineUsersList, getDarkTheme, getDefaultFastCommentsStyles, getLightTheme } from '../sdk';
+import type { FastCommentsStore } from '../sdk';
+import { DemoChrome } from '../chrome/DemoChrome';
+import { buildConfig, CHAT_URL_ID } from '../demo-config';
+import type { ScreenProps } from '../types';
+
+const CODE = `import { FastCommentsLiveChat, OnlineUsersList, getDefaultFastCommentsStyles } from 'fastcomments-react-native-sdk';
+
+const config = {
+  tenantId: 'demo',
+  urlId: 'your-chat-id',
+  defaultSortDirection: 'NF', // newest at the bottom
+  showLiveStatus: true,       // "Live" + online-user header strip
+  simpleSSO: {
+    username: 'Demo User',
+    email: 'demo-user@fctest.com',
+    avatar: 'https://i.pravatar.cc/200?u=fastcomments0',
+  },
+};
+
+// Grab the chat's store and render the online-users list beside it from the
+// same live presence state - no second connection needed. The store is a
+// callable, so stash it via the functional updater (setStore(() => s)).
+const [store, setStore] = useState(null);
+
+<View style={{ flexDirection: 'row', flex: 1 }}>
+  <View style={{ flex: 1 }}>
+    <FastCommentsLiveChat config={config} onStoreReady={(s) => setStore(() => s)} />
+  </View>
+  {/* fill -> the list fills the sidebar column instead of a centered card */}
+  {store && <View style={{ width: 260 }}><OnlineUsersList fill store={store} styles={getDefaultFastCommentsStyles()} /></View>}
+</View>;`;
+
+export function LiveChatScreen({ mode, shell, panelHeight }: ScreenProps) {
+    const theme = mode === 'dark' ? getDarkTheme() : getLightTheme();
+    const config = useMemo(() => buildConfig(CHAT_URL_ID, { defaultSortDirection: 'NF', showLiveStatus: true }), []);
+    const listStyles = useMemo(() => getDefaultFastCommentsStyles(theme), [theme]);
+    const [store, setStore] = useState<FastCommentsStore | null>(null);
+
+    const { width } = useWindowDimensions();
+    const sideBySide = width >= 900;
+
+    return (
+        <DemoChrome
+            shell={shell}
+            breadcrumb="Widgets / Live Chat"
+            title="Live Chat"
+            subtitle="The same SDK in a chat preset: a flat, chronological stream with newest messages at the bottom and infinite history. The online-users list is rendered alongside it - a second component driven by the chat's own live presence store."
+            tags={[{ label: 'demo tenant' }, { label: 'simple sso', brand: true }, { label: 'online users' }]}
+            panelHeight={panelHeight}
+            code={CODE}
+            codeLabel="LiveChatScreen.tsx"
+        >
+            <View style={{ flex: 1, flexDirection: sideBySide ? 'row' : 'column' }}>
+                <View style={{ flex: 1 }}>
+                    {/* The store is a callable (zustand bound hook); pass it via the
+                        functional updater so useState stores it instead of invoking it. */}
+                    <FastCommentsLiveChat key={mode} config={config} theme={theme} onStoreReady={(s) => setStore(() => s)} />
+                </View>
+                {store ? (
+                    <>
+                        <View style={sideBySide ? { width: 1, backgroundColor: shell.border } : { height: 1, backgroundColor: shell.border }} />
+                        <View style={{ width: sideBySide ? 260 : '100%', height: sideBySide ? '100%' : 220 }}>
+                            <OnlineUsersList fill showOffline store={store} styles={listStyles} />
+                        </View>
+                    </>
+                ) : null}
+            </View>
+        </DemoChrome>
+    );
+}

--- a/example-web/src/showcase/screens/LiveCommentingScreen.tsx
+++ b/example-web/src/showcase/screens/LiveCommentingScreen.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
+import {
+    FastCommentsLiveCommenting,
+    FastCommentsLiveCommentingService,
+    GifBrowser,
+    getDarkTheme,
+    getDefaultFastCommentsStyles,
+    getDefaultImageAssets,
+    getLightTheme,
+} from '../sdk';
+import type { FastCommentsCallbacks, FastCommentsStore } from '../sdk';
+import { DemoChrome } from '../chrome/DemoChrome';
+import { buildConfig, SHOWCASE_URL_ID } from '../demo-config';
+import type { ScreenProps } from '../types';
+
+const CODE = `import {
+  FastCommentsLiveCommenting,
+  GifBrowser,
+  getDefaultImageAssets,
+  getDefaultFastCommentsStyles,
+} from 'fastcomments-react-native-sdk';
+
+const config = {
+  tenantId: 'demo',
+  urlId: 'your-page-id',
+  // Simple SSO: no server signing - just a user object. The composer posts as
+  // this identity and the notification bell appears for the signed-in user.
+  simpleSSO: {
+    username: 'Demo User',
+    email: 'demo-user@fctest.com',
+    avatar: 'https://i.pravatar.cc/200?u=fastcomments0',
+  },
+};
+
+// Optional media pickers. pickGIF can use the built-in GifBrowser overlay.
+const callbacks = {
+  pickImage: async () => 'https://example.com/photo.jpg',
+  pickGIF: () => new Promise((resolve) => openGifBrowser(resolve)),
+};
+
+<FastCommentsLiveCommenting config={config} callbacks={callbacks} />;`;
+
+export function LiveCommentingScreen({ mode, shell, panelHeight }: ScreenProps) {
+    const theme = mode === 'dark' ? getDarkTheme() : getLightTheme();
+    const config = useMemo(() => buildConfig(SHOWCASE_URL_ID), []);
+
+    // The GifBrowser overlay runs its own search SDK, so it needs a store. Build
+    // one on demand when the user taps the GIF toolbar button.
+    const [gifResolve, setGifResolve] = useState<((picked: string | false) => void) | null>(null);
+    const gifStoreRef = useRef<FastCommentsStore | null>(null);
+
+    const callbacks: FastCommentsCallbacks = useMemo(
+        () => ({
+            pickImage: async () => 'https://staticm.fastcomments.com/1663891248769-IMG_20200419_092549.jpg',
+            pickGIF: () =>
+                new Promise<string | false>((resolve) => {
+                    gifStoreRef.current = FastCommentsLiveCommentingService.createStoreFromConfig(config, getDefaultImageAssets());
+                    setGifResolve(() => resolve);
+                }),
+        }),
+        [config],
+    );
+
+    const closeGif = (picked: string | false) => {
+        gifResolve?.(picked);
+        setGifResolve(null);
+        gifStoreRef.current = null;
+    };
+
+    return (
+        <DemoChrome
+            shell={shell}
+            breadcrumb="Widgets / Live Commenting"
+            title="Live Commenting"
+            subtitle="Threaded comments with realtime updates and a rich-text composer. This demo wires up GIF + image attachments and the signed-in notification bell - all authenticated with Simple SSO."
+            tags={[{ label: 'demo tenant' }, { label: 'simple sso', brand: true }, { label: 'gifs · notifications' }]}
+            panelHeight={panelHeight}
+            code={CODE}
+            codeLabel="LiveCommentingScreen.tsx"
+        >
+            <View style={{ flex: 1 }}>
+                <FastCommentsLiveCommenting key={mode} config={config} theme={theme} callbacks={callbacks} />
+                {gifResolve && gifStoreRef.current ? (
+                    <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: '#00000088' }}>
+                        <GifBrowser
+                            cancelled={() => closeGif(false)}
+                            pickedGIF={(path) => closeGif(path)}
+                            config={config}
+                            store={gifStoreRef.current}
+                            imageAssets={getDefaultImageAssets()}
+                            styles={getDefaultFastCommentsStyles(theme)}
+                        />
+                    </View>
+                ) : null}
+            </View>
+        </DemoChrome>
+    );
+}

--- a/example-web/src/showcase/sdk.ts
+++ b/example-web/src/showcase/sdk.ts
@@ -1,0 +1,26 @@
+// Single import surface for the SDK so the rest of the showcase doesn't repeat
+// the (deep) relative paths into the package. Public widgets/helpers come from
+// the package root; the store factory + store type live under src/ and aren't
+// part of the published surface, so they're imported directly.
+export {
+    FastCommentsLiveCommenting,
+    FastCommentsLiveChat,
+    FastCommentsFeed,
+    GifBrowser,
+    OnlineUsersList,
+    getLightTheme,
+    getDarkTheme,
+    getDefaultImageAssets,
+    getDefaultFastCommentsStyles,
+} from '../../../index';
+
+export { FastCommentsLiveCommentingService } from '../../../src/services/fastcomments-live-commenting';
+
+export type {
+    FastCommentsRNConfig,
+    FastCommentsCallbacks,
+    ImageAssetConfig,
+    IFastCommentsStyles,
+} from '../../../index';
+
+export type { FastCommentsStore } from '../../../src/store/types';

--- a/example-web/src/showcase/sdk.ts
+++ b/example-web/src/showcase/sdk.ts
@@ -6,6 +6,7 @@ export {
     FastCommentsLiveCommenting,
     FastCommentsLiveChat,
     FastCommentsFeed,
+    FastCommentsFeedPostCreate,
     GifBrowser,
     OnlineUsersList,
     getLightTheme,

--- a/example-web/src/showcase/types.ts
+++ b/example-web/src/showcase/types.ts
@@ -1,0 +1,11 @@
+import type { ShellTheme, ThemeMode } from './chrome/shell-theme';
+
+// Props every demo screen receives from the Showcase shell.
+export interface ScreenProps {
+    /** Global light/dark mode; drives the SDK widget theme. */
+    mode: ThemeMode;
+    /** Resolved chrome palette for the surrounding DemoChrome. */
+    shell: ShellTheme;
+    /** Height for the live-widget panel, sized to the viewport by the shell. */
+    panelHeight: number;
+}

--- a/example-web/tests/feed.test.tsx
+++ b/example-web/tests/feed.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Web-lane render tests for the feed post row + standalone composer. Mounts
+ * through react-native-web with a real store (posts/auth would normally come
+ * from the feed APIs / SSO).
+ */
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { FeedPostRow } from '../../src/components/feed-post-row';
+import { FastCommentsFeedPostCreate } from '../../src/components/feed-post-create';
+import { FastCommentsLiveCommentingService } from '../../src/services/fastcomments-live-commenting';
+import { getDefaultFastCommentsStyles } from '../../src/resources/styles';
+import type { FeedPost } from '../../src/types/feed-post';
+
+afterEach(cleanup);
+
+const styles = getDefaultFastCommentsStyles();
+
+function makeStore() {
+    return FastCommentsLiveCommentingService.createStoreFromConfig({
+        tenantId: 'demo',
+        urlId: 'feed-test',
+        apiHost: 'https://fastcomments.com',
+    });
+}
+
+const post: FeedPost = {
+    id: 'p1',
+    tenantId: 'demo',
+    fromUserId: 'u1',
+    fromUserDisplayName: 'Author',
+    fromUserAvatar: 'https://i.pravatar.cc/100?img=3',
+    title: 'Hello',
+    contentHTML: '<p>Body <b>bold</b></p>',
+    createdAt: Date.now(),
+    commentCount: 3,
+};
+
+describe('FeedPostRow', () => {
+    it('renders the row with a comment button (count) and a share button', () => {
+        const store = makeStore();
+        const { getByTestId } = render(
+            <FeedPostRow post={post} translations={{ JUST_NOW: "just now" }} styles={styles} store={store} followStateRevision={0} />
+        );
+        expect(getByTestId('feedPostRow-p1')).toBeTruthy();
+        expect(getByTestId('feedPostCommentButton-p1').textContent).toContain('(3)');
+        expect(getByTestId('feedPostShareButton-p1')).toBeTruthy();
+    });
+
+    it('shows the delete menu only on the viewer\'s own posts', () => {
+        const store = makeStore();
+        const { queryByTestId, rerender } = render(
+            <FeedPostRow post={post} translations={{ JUST_NOW: "just now" }} styles={styles} store={store} followStateRevision={0} currentUser={{ id: 'other' } as never} />
+        );
+        expect(queryByTestId('feedPostMenu-p1')).toBeNull();
+        rerender(
+            <FeedPostRow post={post} translations={{ JUST_NOW: "just now" }} styles={styles} store={store} followStateRevision={0} currentUser={{ id: 'u1' } as never} />
+        );
+        expect(queryByTestId('feedPostMenu-p1')).toBeTruthy();
+    });
+});
+
+describe('FastCommentsFeedPostCreate', () => {
+    it('renders the author header, title field, and submit button', () => {
+        const store = makeStore();
+        const { getByTestId } = render(<FastCommentsFeedPostCreate store={store} styles={styles} />);
+        expect(getByTestId('feedPostCreate')).toBeTruthy();
+        expect(getByTestId('postTitleEditText')).toBeTruthy();
+        expect(getByTestId('submitPostButton')).toBeTruthy();
+    });
+});

--- a/example-web/tests/online-users.test.tsx
+++ b/example-web/tests/online-users.test.tsx
@@ -19,6 +19,16 @@ function storeWithOnlineUsers(count: number, total = count) {
         urlId: 'online-users-test',
         apiHost: 'https://fastcomments.com',
     });
+    // The widgets self-load their snapshot on mount (ensureOnlineUsersLoaded);
+    // stub the endpoint so these render-only tests never hit the network.
+    (store.getState().sdk.publicApi as any).getOnlineUsers = async () => ({
+        status: 'success',
+        users: [],
+        totalCount: total,
+        anonCount: 0,
+        nextAfterUserId: null,
+        nextAfterName: null,
+    });
     const users = Array.from({ length: count }, (_, i) => ({
         id: `u${i}`,
         displayName: `User ${i}`,

--- a/index.ts
+++ b/index.ts
@@ -2,3 +2,6 @@ export * from './src/components';
 export * from './src/resources';
 export * from './src/skins';
 export * from './src/types';
+// Store handle type, for consumers wiring store-driven widgets (e.g.
+// OnlineUsersList) to a widget's store via the onStoreReady callback.
+export type { FastCommentsStore } from './src/store/types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastcomments-react-native-sdk",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fastcomments-react-native-sdk",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.184",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastcomments-react-native-sdk",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "React Native FastComments Components. Add live commenting to any React Native application.",
   "main": "index.ts",
   "react-native": "index.ts",

--- a/src/components/comment-text-area.tsx
+++ b/src/components/comment-text-area.tsx
@@ -85,6 +85,8 @@ export interface CommentTextAreaProps extends Pick<FastCommentsCallbacks, 'pickI
     onFocus?: () => void
     /** Submit the comment (web: Ctrl/Cmd+Enter inside the editor). **/
     onSubmit?: () => void
+    /** Fires with the editor HTML on every change (e.g. to enable a submit button). **/
+    onChange?: (html: string) => void
     /** Show the in-flight save shimmer over the editor box. **/
     saving?: boolean
     value?: string
@@ -121,6 +123,7 @@ export function CommentTextArea({
     output,
     onFocus,
     onSubmit,
+    onChange,
     saving,
     pickImage,
     pickGIF,
@@ -326,9 +329,14 @@ export function CommentTextArea({
         };
     }, [output]);
 
+    // Mirror onChange through a ref so the once-created callback always calls the
+    // latest handler without re-binding (same pattern as onSubmitRef).
+    const onChangeRef = useRef<((html: string) => void) | undefined>(onChange);
+    onChangeRef.current = onChange;
     const onChangeHtml = useCallback((e: NativeSyntheticEvent<OnChangeHtmlEvent>) => {
         const next = e.nativeEvent.value;
         htmlRef.current = next;
+        onChangeRef.current?.(next);
         setMentionQuery(detectMentionQuery(next));
     }, []);
 

--- a/src/components/feed-post-create.tsx
+++ b/src/components/feed-post-create.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Image, ImageURISource, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import type { FastCommentsStore } from '../store/types';
+import type { IFastCommentsStyles, FastCommentsCallbacks, ImageAssetConfig } from '../types';
+import type { FastCommentsRNConfig } from '../types/react-native-config';
+import type { FastCommentsThemeOverrides } from '../types/fastcomments-theme';
+import type { CreateFeedPostParams, FeedPost, FeedPostLink, FeedPostMediaItem } from '../types/feed-post';
+import type { FastCommentsSessionUser } from '../types/user';
+import { FastCommentsLiveCommentingService } from '../services/fastcomments-live-commenting';
+import { resolveStyles } from '../resources/resolve-styles';
+import { isDarkColor, resolveTheme } from '../resources/themes';
+import { useStoreValue } from '../store/hooks';
+import { CommentTextArea, type ValueObserver } from './comment-text-area';
+import { editorHtmlToServerHtml } from '../services/editor/editor-html-to-server-html';
+import { FeedPostMediaAttach, type AttachedMediaPending } from './feed-post-media-attach';
+import { createFeedPost, setupFeedTranslations, uploadFeedMediaItem } from '../services/feed';
+import { getDefaultAvatarSrc } from '../services/default-avatar';
+
+const MAX_ITEMS = 10;
+
+/** API handed to a custom composer toolbar button (e.g. a sticker/GIF source). */
+export interface FeedComposerToolbarApi {
+    /** Attach media: an http(s) url is kept as a remote item; anything else is uploaded on submit. */
+    addMedia: (uriOrUrl: string) => void;
+    store: FastCommentsStore;
+}
+
+/** A host-supplied button in the composer's action row (mirrors Android's custom toolbar buttons). */
+export interface FeedComposerToolbarButton {
+    id: string;
+    label?: string;
+    icon?: ImageURISource;
+    onPress: (api: FeedComposerToolbarApi) => void | Promise<void>;
+}
+
+interface FeedPostCreateCommonProps extends Pick<FastCommentsCallbacks, 'pickImage' | 'pickGIF' | 'onError'> {
+    /** Raw style overrides (merged on a themed tree when `theme` is also given). **/
+    styles?: IFastCommentsStyles;
+    /** Semantic design tokens. **/
+    theme?: FastCommentsThemeOverrides;
+    onPostCreated?: (post: FeedPost) => void;
+    onPostCreateError?: (message: string) => void;
+    onCancel?: () => void;
+    /** Show a Cancel button that resets the form and calls onCancel. **/
+    showCancel?: boolean;
+    /** Show the optional title field above the editor. Default true. **/
+    showTitle?: boolean;
+    /** Host-supplied composer buttons (e.g. a GIF/sticker source). **/
+    toolbarButtons?: FeedComposerToolbarButton[];
+    /** Resolve tags at submit time from the current user (Android's TagSupplier). **/
+    tagSupplier?: (currentUser: FastCommentsSessionUser | undefined) => string[];
+}
+
+/**
+ * Either share the feed's live store (recommended - new posts appear instantly),
+ * or pass a config and the composer manages its own store.
+ */
+export type FastCommentsFeedPostCreateProps = FeedPostCreateCommonProps &
+    ({ store: FastCommentsStore; config?: undefined; assets?: undefined } | { store?: undefined; config: FastCommentsRNConfig; assets?: ImageAssetConfig });
+
+function nextKey(): string {
+    return `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function userField<T = string>(user: FastCommentsSessionUser | undefined, field: string): T | undefined {
+    if (user && typeof user === 'object' && field in user) {
+        const v = (user as Record<string, unknown>)[field];
+        if (v != null) return v as T;
+    }
+    return undefined;
+}
+
+/**
+ * Standalone feed post composer at parity with the Android SDK's
+ * `FeedPostCreateView`: author header, a rich text editor (reuses the comments
+ * enriched editor), separate media attachments (≤10, local + remote/GIF), link
+ * attachments, tags, custom toolbar buttons, and cancel/loading/error. Place it
+ * anywhere; share the feed's store (via `onStoreReady`) so posts appear at once.
+ */
+export function FastCommentsFeedPostCreate(props: FastCommentsFeedPostCreateProps) {
+    const { styles: stylesProp, theme, onPostCreated, onPostCreateError, onCancel, showCancel, showTitle = true, toolbarButtons, tagSupplier, pickImage, pickGIF } = props;
+    const effectiveStyles = useMemo(() => resolveStyles(stylesProp, theme), [stylesProp, theme]);
+
+    // Use the shared store, or create + init one (self-managed mode).
+    const storeRef = useRef<FastCommentsStore | null>(null);
+    const selfManagedRef = useRef(false);
+    if (storeRef.current === null) {
+        if (props.store) {
+            storeRef.current = props.store;
+        } else {
+            const cfg = props.config;
+            const hasDarkBackground = cfg.hasDarkBackground ?? (theme ? isDarkColor(resolveTheme(theme).colors.background) : undefined);
+            storeRef.current = FastCommentsLiveCommentingService.createStoreFromConfig({ ...cfg, hasDarkBackground }, props.assets);
+            selfManagedRef.current = true;
+        }
+    }
+    const store = storeRef.current!;
+
+    useEffect(() => {
+        // Self-managed mode has no feed to load translations; do it here.
+        if (selfManagedRef.current) {
+            void setupFeedTranslations(store, store.getState().config.locale);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const translations = useStoreValue(store, (s) => s.translations);
+    const imageAssets = useStoreValue(store, (s) => s.imageAssets);
+    const currentUser = useStoreValue(store, (s) => s.currentUser);
+
+    const [title, setTitle] = useState('');
+    const [attached, setAttached] = useState<AttachedMediaPending[]>([]);
+    const [links, setLinks] = useState<FeedPostLink[]>([]);
+    const [linkDraft, setLinkDraft] = useState('');
+    const [showLinkInput, setShowLinkInput] = useState(false);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | undefined>(undefined);
+    const [hasText, setHasText] = useState(false);
+
+    // Stable observer for reading/clearing the editor HTML imperatively.
+    const output = useMemo<ValueObserver>(() => ({}), []);
+
+    const authorName = userField<string>(currentUser, 'username') || translations.FEED_COMPOSER_ANONYMOUS || 'Anonymous';
+    const authorAvatar = userField<string>(currentUser, 'avatarSrc');
+
+    const canSubmit = !busy && (hasText || attached.length > 0 || links.length > 0 || title.trim().length > 0);
+
+    const addMedia = (uriOrUrl: string) => {
+        setAttached((prev) => {
+            if (prev.length >= MAX_ITEMS) return prev;
+            if (uriOrUrl.startsWith('http')) {
+                return [...prev, { key: nextKey(), previewUri: uriOrUrl, remoteItem: { sizes: [{ src: uriOrUrl, w: 400, h: 300 }] } }];
+            }
+            return [...prev, { key: nextKey(), previewUri: uriOrUrl, sourceForUpload: uriOrUrl }];
+        });
+    };
+
+    const onPick = async () => {
+        if (!pickImage || busy || attached.length >= MAX_ITEMS) return;
+        try {
+            const photoData = await pickImage();
+            if (!photoData) return;
+            if (typeof photoData === 'string') {
+                addMedia(photoData);
+                return;
+            }
+            const uri = photoData.uri || photoData.base64;
+            if (uri) addMedia(uri);
+        } catch {
+            setError(translations.FEED_MEDIA_UPLOAD_FAILED);
+        }
+    };
+
+    const onAddLink = () => {
+        const url = linkDraft.trim();
+        if (!url) return;
+        setLinks((prev) => [...prev, { url }]);
+        setLinkDraft('');
+        setShowLinkInput(false);
+    };
+
+    const resetForm = () => {
+        setTitle('');
+        setAttached([]);
+        setLinks([]);
+        setLinkDraft('');
+        setShowLinkInput(false);
+        setHasText(false);
+        setError(undefined);
+        output.reset?.();
+    };
+
+    const onSubmit = async () => {
+        if (!canSubmit) return;
+        setBusy(true);
+        setError(undefined);
+        try {
+            // Upload pending local media; keep remote items as-is.
+            const media: FeedPostMediaItem[] = [];
+            for (const item of attached) {
+                if (item.remoteItem) {
+                    media.push(item.remoteItem);
+                    continue;
+                }
+                if (!item.sourceForUpload) continue;
+                setAttached((prev) => prev.map((m) => (m.key === item.key ? { ...m, progress: 0 } : m)));
+                const result = await uploadFeedMediaItem(store, item.sourceForUpload, (loaded, total) => {
+                    const ratio = total > 0 ? loaded / total : 0;
+                    setAttached((prev) => prev.map((m) => (m.key === item.key ? { ...m, progress: ratio } : m)));
+                });
+                if ('error' in result) {
+                    setAttached((prev) => prev.map((m) => (m.key === item.key ? { ...m, progress: undefined, errorKey: 'FEED_MEDIA_UPLOAD_FAILED' } : m)));
+                    setError(translations.FEED_MEDIA_UPLOAD_FAILED);
+                    return;
+                }
+                media.push(result.item);
+            }
+
+            const serverHtml = editorHtmlToServerHtml(output.getValue?.() ?? '');
+            const contentHasText = serverHtml.replace(/<[^>]*>/g, '').trim().length > 0;
+            const tags = tagSupplier ? tagSupplier(currentUser) : undefined;
+            const params: CreateFeedPostParams = {
+                title: title.trim() ? title.trim() : undefined,
+                contentHTML: contentHasText ? serverHtml : undefined,
+                media: media.length > 0 ? media : undefined,
+                links: links.length > 0 ? links : undefined,
+                tags: tags && tags.length > 0 ? tags : undefined,
+                fromUserId: userField<string>(currentUser, 'id'),
+                fromUserDisplayName: userField<string>(currentUser, 'username'),
+            };
+
+            const res = await createFeedPost(store, params);
+            if ('error' in res) {
+                setError(translations.FEED_LOAD_FAILED || res.error);
+                onPostCreateError?.(res.error);
+                return;
+            }
+            resetForm();
+            onPostCreated?.(res.post);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const f = effectiveStyles.feed;
+    return (
+        <View style={f?.composer} testID="feedPostCreate" accessibilityLabel="feedPostCreate">
+            <View style={f?.composerHeader}>
+                <Image
+                    style={f?.composerAvatar}
+                    source={authorAvatar ? { uri: authorAvatar } : getDefaultAvatarSrc(imageAssets)}
+                />
+                <Text style={f?.composerAuthorName} numberOfLines={1}>{authorName}</Text>
+            </View>
+
+            {showTitle && (
+                <TextInput
+                    testID="postTitleEditText"
+                    accessibilityLabel="postTitleEditText"
+                    style={f?.composerInputTitle}
+                    placeholder={translations.FEED_COMPOSER_TITLE_PLACEHOLDER}
+                    value={title}
+                    onChangeText={setTitle}
+                    editable={!busy}
+                />
+            )}
+
+            <CommentTextArea
+                store={store}
+                styles={effectiveStyles}
+                output={output}
+                onChange={(html) => setHasText(html.replace(/<[^>]*>/g, '').trim().length > 0)}
+                onSubmit={onSubmit}
+                saving={busy}
+                // Media lives in the separate attachment list (Android-style), so
+                // the editor handles text/formatting only - no inline image/GIF.
+                toolbarButtons={{ bold: true, italic: true, underline: true, strikethrough: true, code: false, image: false, gif: false }}
+            />
+
+            {pickImage && (
+                <FeedPostMediaAttach
+                    translations={translations}
+                    styles={effectiveStyles}
+                    items={attached}
+                    disabled={busy}
+                    onPick={onPick}
+                    onRemove={(key) => setAttached((prev) => prev.filter((m) => m.key !== key))}
+                />
+            )}
+
+            {links.length > 0 && (
+                <View style={f?.composerLinkList}>
+                    {links.map((link, i) => (
+                        <View key={`${link.url}-${i}`} style={f?.composerLinkPreview}>
+                            <Text style={f?.composerLinkPreviewText} numberOfLines={1}>{link.title || link.url}</Text>
+                            <TouchableOpacity onPress={() => setLinks((prev) => prev.filter((_, idx) => idx !== i))}>
+                                <Text style={f?.composerLinkRemove}>{translations.FEED_COMPOSER_REMOVE_LINK || '✕'}</Text>
+                            </TouchableOpacity>
+                        </View>
+                    ))}
+                </View>
+            )}
+
+            {showLinkInput ? (
+                <View style={f?.composerLinkRow}>
+                    <TextInput
+                        testID="feedComposerLinkInput"
+                        accessibilityLabel="feedComposerLinkInput"
+                        style={f?.composerLinkInput}
+                        placeholder={translations.FEED_COMPOSER_LINK_PLACEHOLDER || 'https://…'}
+                        value={linkDraft}
+                        onChangeText={setLinkDraft}
+                        autoCapitalize="none"
+                        editable={!busy}
+                        onSubmitEditing={onAddLink}
+                    />
+                    <TouchableOpacity style={f?.composerLinkAddButton} onPress={onAddLink}>
+                        <Text style={f?.composerLinkAddButtonText}>{translations.FEED_COMPOSER_ADD_LINK || 'Add'}</Text>
+                    </TouchableOpacity>
+                </View>
+            ) : null}
+
+            {(toolbarButtons?.length || !showLinkInput) ? (
+                <View style={f?.composerToolbar}>
+                    {!showLinkInput && (
+                        <TouchableOpacity
+                            testID="feedComposerAddLinkButton"
+                            accessibilityLabel="feedComposerAddLinkButton"
+                            style={f?.composerToolbarButton}
+                            onPress={() => setShowLinkInput(true)}
+                            disabled={busy}
+                        >
+                            <Text style={f?.composerToolbarButtonLabel}>{translations.FEED_COMPOSER_LINK_BUTTON || '🔗'}</Text>
+                        </TouchableOpacity>
+                    )}
+                    {(toolbarButtons ?? []).map((btn) => (
+                        <TouchableOpacity
+                            key={btn.id}
+                            testID={`feedComposerButton-${btn.id}`}
+                            accessibilityLabel={`feedComposerButton-${btn.id}`}
+                            style={f?.composerToolbarButton}
+                            disabled={busy}
+                            onPress={() => btn.onPress({ addMedia, store })}
+                        >
+                            {btn.icon ? <Image source={btn.icon} style={f?.composerToolbarButtonIcon} /> : null}
+                            {btn.label ? <Text style={f?.composerToolbarButtonLabel}>{btn.label}</Text> : null}
+                        </TouchableOpacity>
+                    ))}
+                </View>
+            ) : null}
+
+            {error && (
+                <Text testID="feedComposerError" accessibilityLabel="feedComposerError" style={f?.composerMediaPreviewError}>
+                    {error}
+                </Text>
+            )}
+
+            <View style={f?.composerActions}>
+                {showCancel && (
+                    <TouchableOpacity
+                        testID="feedComposerCancel"
+                        accessibilityLabel="feedComposerCancel"
+                        style={f?.composerCancel}
+                        disabled={busy}
+                        onPress={() => {
+                            resetForm();
+                            onCancel?.();
+                        }}
+                    >
+                        <Text style={f?.composerCancelText}>{translations.FEED_COMPOSER_CANCEL || 'Cancel'}</Text>
+                    </TouchableOpacity>
+                )}
+                <TouchableOpacity
+                    testID="submitPostButton"
+                    accessibilityLabel="submitPostButton"
+                    style={[f?.composerSubmit, !canSubmit ? f?.composerSubmitDisabled : null]}
+                    onPress={onSubmit}
+                    disabled={!canSubmit}
+                >
+                    <Text style={f?.composerSubmitText}>{translations.FEED_SUBMIT_POST}</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+}

--- a/src/components/feed-post-media-gallery.tsx
+++ b/src/components/feed-post-media-gallery.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Image, NativeScrollEvent, NativeSyntheticEvent, ScrollView, View } from 'react-native';
+import { useRef, useState } from 'react';
+import { Image, NativeScrollEvent, NativeSyntheticEvent, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import type { IFastCommentsStyles } from '../types';
 import type { FeedPostMediaItem, FeedPostMediaItemAsset } from '../types/feed-post';
 
@@ -25,11 +25,13 @@ function pickBestSize(item: FeedPostMediaItem): FeedPostMediaItemAsset | undefin
 /**
  * Typed image layouts (mirrors Android's SINGLE_IMAGE / MULTI_IMAGE): one image
  * renders full-width at its own aspect ratio; multiple render as a paging
- * carousel with index dots.
+ * carousel with prev/next controls and tappable index dots (swipe works on
+ * touch; the controls make it navigable on desktop web too).
  */
 export function FeedPostMediaGallery({ postId, media, styles }: FeedPostMediaGalleryProps) {
     const [width, setWidth] = useState(0);
     const [active, setActive] = useState(0);
+    const scrollRef = useRef<ScrollView>(null);
     if (!media || media.length === 0) return null;
     const f = styles.feed;
     const single = media.length === 1;
@@ -64,6 +66,11 @@ export function FeedPostMediaGallery({ postId, media, styles }: FeedPostMediaGal
         );
     }
 
+    const goTo = (i: number) => {
+        const clamped = Math.max(0, Math.min(media.length - 1, i));
+        if (width > 0) scrollRef.current?.scrollTo({ x: clamped * width, animated: true });
+        setActive(clamped);
+    };
     const onMomentumEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
         if (width > 0) setActive(Math.round(e.nativeEvent.contentOffset.x / width));
     };
@@ -75,22 +82,57 @@ export function FeedPostMediaGallery({ postId, media, styles }: FeedPostMediaGal
             style={f?.postMediaGallery}
             onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
         >
-            <ScrollView
-                horizontal
-                pagingEnabled
-                showsHorizontalScrollIndicator={false}
-                onMomentumScrollEnd={onMomentumEnd}
-                scrollEventThrottle={16}
-            >
-                {media.map((item, idx) => (
-                    <View key={`${postId}-page-${idx}`} style={width > 0 ? { width } : undefined}>
-                        {renderImage(item, idx)}
-                    </View>
-                ))}
-            </ScrollView>
+            <View style={f?.postMediaCarousel}>
+                <ScrollView
+                    ref={scrollRef}
+                    horizontal
+                    pagingEnabled
+                    showsHorizontalScrollIndicator={false}
+                    onMomentumScrollEnd={onMomentumEnd}
+                    scrollEventThrottle={16}
+                >
+                    {media.map((item, idx) => (
+                        <View key={`${postId}-page-${idx}`} style={width > 0 ? { width } : undefined}>
+                            {renderImage(item, idx)}
+                        </View>
+                    ))}
+                </ScrollView>
+                {width > 0 && active > 0 ? (
+                    <TouchableOpacity
+                        testID={`feedPostMediaPrev-${postId}`}
+                        accessibilityLabel="feedPostMediaPrev"
+                        style={[f?.postMediaNav, { left: 0 }]}
+                        onPress={() => goTo(active - 1)}
+                    >
+                        <View style={f?.postMediaNavButton}>
+                            <Text style={f?.postMediaNavText}>‹</Text>
+                        </View>
+                    </TouchableOpacity>
+                ) : null}
+                {width > 0 && active < media.length - 1 ? (
+                    <TouchableOpacity
+                        testID={`feedPostMediaNext-${postId}`}
+                        accessibilityLabel="feedPostMediaNext"
+                        style={[f?.postMediaNav, { right: 0 }]}
+                        onPress={() => goTo(active + 1)}
+                    >
+                        <View style={f?.postMediaNavButton}>
+                            <Text style={f?.postMediaNavText}>›</Text>
+                        </View>
+                    </TouchableOpacity>
+                ) : null}
+            </View>
             <View style={f?.postMediaDots} testID={`feedPostMediaDots-${postId}`}>
                 {media.map((_, idx) => (
-                    <View key={`${postId}-dot-${idx}`} style={[f?.postMediaDot, idx === active ? f?.postMediaDotActive : null]} />
+                    <TouchableOpacity
+                        key={`${postId}-dot-${idx}`}
+                        testID={`feedPostMediaDot-${postId}-${idx}`}
+                        accessibilityLabel="feedPostMediaDot"
+                        style={f?.postMediaDotButton}
+                        onPress={() => goTo(idx)}
+                    >
+                        <View style={[f?.postMediaDot, idx === active ? f?.postMediaDotActive : null]} />
+                    </TouchableOpacity>
                 ))}
             </View>
         </View>

--- a/src/components/feed-post-media-gallery.tsx
+++ b/src/components/feed-post-media-gallery.tsx
@@ -1,4 +1,5 @@
-import { Image, ScrollView, View } from 'react-native';
+import { useState } from 'react';
+import { Image, NativeScrollEvent, NativeSyntheticEvent, ScrollView, View } from 'react-native';
 import type { IFastCommentsStyles } from '../types';
 import type { FeedPostMediaItem, FeedPostMediaItemAsset } from '../types/feed-post';
 
@@ -21,32 +22,77 @@ function pickBestSize(item: FeedPostMediaItem): FeedPostMediaItemAsset | undefin
     return best;
 }
 
+/**
+ * Typed image layouts (mirrors Android's SINGLE_IMAGE / MULTI_IMAGE): one image
+ * renders full-width at its own aspect ratio; multiple render as a paging
+ * carousel with index dots.
+ */
 export function FeedPostMediaGallery({ postId, media, styles }: FeedPostMediaGalleryProps) {
+    const [width, setWidth] = useState(0);
+    const [active, setActive] = useState(0);
     if (!media || media.length === 0) return null;
+    const f = styles.feed;
+    const single = media.length === 1;
+
+    const renderImage = (item: FeedPostMediaItem, idx: number) => {
+        const asset = pickBestSize(item);
+        if (!asset || !asset.src) return null;
+        const ratio = asset.w && asset.h ? asset.w / asset.h : 1.5;
+        const sized = width > 0 ? { width, height: Math.round(width / ratio) } : null;
+        return (
+            <Image
+                key={`${postId}-${idx}`}
+                testID={`feedPostMediaItem-${postId}-${idx}`}
+                accessibilityLabel={`feedPostMediaItem-${postId}-${idx}`}
+                source={{ uri: asset.src }}
+                style={[f?.postMediaImage, sized]}
+                resizeMode="cover"
+            />
+        );
+    };
+
+    if (single) {
+        return (
+            <View
+                testID={`feedPostMedia-${postId}`}
+                accessibilityLabel={`feedPostMedia-${postId}`}
+                style={f?.postMediaGallery}
+                onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
+            >
+                {renderImage(media[0], 0)}
+            </View>
+        );
+    }
+
+    const onMomentumEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+        if (width > 0) setActive(Math.round(e.nativeEvent.contentOffset.x / width));
+    };
+
     return (
-        <ScrollView
-            horizontal
+        <View
             testID={`feedPostMedia-${postId}`}
             accessibilityLabel={`feedPostMedia-${postId}`}
-            style={styles.feed?.postMediaGallery}
-            showsHorizontalScrollIndicator={false}
+            style={f?.postMediaGallery}
+            onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
         >
-            {media.map((item, idx) => {
-                const asset = pickBestSize(item);
-                if (!asset || !asset.src) return null;
-                return (
-                    <View
-                        key={`${postId}-${idx}`}
-                        testID={`feedPostMediaItem-${postId}-${idx}`}
-                        accessibilityLabel={`feedPostMediaItem-${postId}-${idx}`}
-                    >
-                        <Image
-                            source={{ uri: asset.src }}
-                            style={styles.feed?.postMediaImage}
-                        />
+            <ScrollView
+                horizontal
+                pagingEnabled
+                showsHorizontalScrollIndicator={false}
+                onMomentumScrollEnd={onMomentumEnd}
+                scrollEventThrottle={16}
+            >
+                {media.map((item, idx) => (
+                    <View key={`${postId}-page-${idx}`} style={width > 0 ? { width } : undefined}>
+                        {renderImage(item, idx)}
                     </View>
-                );
-            })}
-        </ScrollView>
+                ))}
+            </ScrollView>
+            <View style={f?.postMediaDots} testID={`feedPostMediaDots-${postId}`}>
+                {media.map((_, idx) => (
+                    <View key={`${postId}-dot-${idx}`} style={[f?.postMediaDot, idx === active ? f?.postMediaDotActive : null]} />
+                ))}
+            </View>
+        </View>
     );
 }

--- a/src/components/feed-post-media-gallery.tsx
+++ b/src/components/feed-post-media-gallery.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Image, NativeScrollEvent, NativeSyntheticEvent, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { Image, NativeScrollEvent, NativeSyntheticEvent, ScrollView, TouchableOpacity, View } from 'react-native';
 import type { IFastCommentsStyles } from '../types';
 import type { FeedPostMediaItem, FeedPostMediaItemAsset } from '../types/feed-post';
 
@@ -105,7 +105,7 @@ export function FeedPostMediaGallery({ postId, media, styles }: FeedPostMediaGal
                         onPress={() => goTo(active - 1)}
                     >
                         <View style={f?.postMediaNavButton}>
-                            <Text style={f?.postMediaNavText}>‹</Text>
+                            <View style={[f?.postMediaChevron, f?.postMediaChevronPrev]} />
                         </View>
                     </TouchableOpacity>
                 ) : null}
@@ -117,7 +117,7 @@ export function FeedPostMediaGallery({ postId, media, styles }: FeedPostMediaGal
                         onPress={() => goTo(active + 1)}
                     >
                         <View style={f?.postMediaNavButton}>
-                            <Text style={f?.postMediaNavText}>›</Text>
+                            <View style={[f?.postMediaChevron, f?.postMediaChevronNext]} />
                         </View>
                     </TouchableOpacity>
                 ) : null}

--- a/src/components/feed-post-row.tsx
+++ b/src/components/feed-post-row.tsx
@@ -1,40 +1,35 @@
-import { memo } from 'react';
-import { Text, View } from 'react-native';
+import { memo, useMemo, useState } from 'react';
+import { Image, Modal, Share, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+import RenderHtml, { type MixedStyleDeclaration } from 'react-native-render-html';
 import type { FeedPost } from '../types/feed-post';
 import type { FeedCustomToolbarButton } from '../types/feed-custom-toolbar-button';
-import type { IFastCommentsStyles } from '../types';
+import type { IFastCommentsStyles, FastCommentsCallbacks } from '../types';
+import { FastCommentsImageAsset } from '../types';
 import type { FastCommentsStore } from '../store/types';
 import type { FastCommentsSessionUser } from '../types/user';
 import type { FollowStateProvider } from '../types/follow-state-provider';
 import { getPrettyDate } from '../services/pretty-date';
+import { buildPostCommentsConfig, deleteFeedPost } from '../services/feed';
+import { showConfirmDialog } from '../services/dialogs';
+import { getDefaultAvatarSrc } from '../services/default-avatar';
 import { FeedCustomToolbarButtonView } from './feed-custom-toolbar-button';
 import { FeedFollowPill } from './feed-follow-pill';
 import { FeedPostMediaGallery } from './feed-post-media-gallery';
 import { FeedPostReactions } from './feed-post-reactions';
+import { FastCommentsLiveCommenting } from './live-commenting';
 
 export interface FeedPostRowProps {
     post: FeedPost;
     translations: Record<string, string>;
     styles: IFastCommentsStyles;
     customToolbarButtons?: FeedCustomToolbarButton[];
-    /**
-     * Store reference. Required for reactions; if absent the reactions strip
-     * is suppressed.
-     */
+    /** Store reference. Required for reactions/comments/delete; if absent those are suppressed. */
     store?: FastCommentsStore;
-    /**
-     * Viewer user id. When undefined or equal to the post's author id the
-     * follow pill is suppressed.
-     */
+    /** Forwarded to the per-post comments widget composer. */
+    callbacks?: FastCommentsCallbacks;
+    /** Viewer user; when it matches the author the follow pill is hidden and the delete menu shows. */
     currentUser?: FastCommentsSessionUser;
-    /**
-     * Host-supplied follow state. When absent, no follow pill is rendered.
-     */
     followStateProvider?: FollowStateProvider;
-    /**
-     * Bumped by the parent feed when host follow state has changed externally
-     * so the pill rebinds via {@link FollowStateProvider#isFollowing}.
-     */
     followStateRevision: number;
 }
 
@@ -58,10 +53,6 @@ function decodeEntities(input: string): string {
 
 function stripHtml(input: string | undefined): string {
     if (!input) return '';
-    // Strip tags first, then decode entities. Decoding first would turn
-    // attacker-encoded `&lt;script&gt;` into real `<script>` tags before the
-    // strip ran. Output goes only into a `<Text>`, but ordering should not
-    // depend on that being the only consumer.
     return decodeEntities(input.replace(/<[^>]*>/g, '')).trim();
 }
 
@@ -72,28 +63,72 @@ function toEpoch(value: FeedPost['createdAt']): number {
     return Date.now();
 }
 
-function FeedPostRowImpl({ post, translations, styles, customToolbarButtons, store, currentUser, followStateProvider, followStateRevision }: FeedPostRowProps) {
+async function sharePost(post: FeedPost) {
+    const text = post.title || stripHtml(post.contentHTML) || '';
+    try {
+        const nav = typeof navigator !== 'undefined' ? (navigator as unknown as { share?: (d: unknown) => Promise<void> }) : undefined;
+        if (nav?.share) {
+            await nav.share({ title: post.title, text });
+            return;
+        }
+        await Share.share({ title: post.title, message: text });
+    } catch {
+        // user cancelled / share unavailable - no-op
+    }
+}
+
+function FeedPostRowImpl({ post, translations, styles, customToolbarButtons, store, callbacks, currentUser, followStateProvider, followStateRevision }: FeedPostRowProps) {
+    const { width } = useWindowDimensions();
+    const [commentsOpen, setCommentsOpen] = useState(false);
+    // config + imageAssets are stable for the store's lifetime, so read them
+    // non-reactively (avoids a conditional hook when `store` is absent).
+    const snapshot = store?.getState();
+    const feedConfig = snapshot?.config;
+    const imageAssets = snapshot?.imageAssets;
+
     const author = post.fromUserDisplayName ?? '';
-    const content = stripHtml(post.contentHTML);
     const ts = toEpoch(post.createdAt);
     const date = getPrettyDate(translations, ts);
-    const visibleButtons = (customToolbarButtons ?? []).filter(
-        (button) => !button.visible || button.visible(post)
-    );
+
+    const visibleButtons = (customToolbarButtons ?? []).filter((button) => !button.visible || button.visible(post));
     const viewerId = getCurrentUserId(currentUser);
-    const showFollowPill =
-        !!followStateProvider &&
-        !!post.fromUserId &&
-        !!viewerId &&
-        post.fromUserId !== viewerId;
+    const showFollowPill = !!followStateProvider && !!post.fromUserId && !!viewerId && post.fromUserId !== viewerId;
+    const canDelete = !!store && !!viewerId && !!post.fromUserId && post.fromUserId === viewerId;
+    const f = styles.feed;
+
+    const contentHTML = post.contentHTML;
+    const commentsConfig = useMemo(
+        () => (store && feedConfig ? buildPostCommentsConfig(post, feedConfig) : undefined),
+        [store, feedConfig, post]
+    );
+
+    const avatarSource = post.fromUserAvatar
+        ? { uri: post.fromUserAvatar }
+        : imageAssets
+        ? getDefaultAvatarSrc(imageAssets)
+        : undefined;
+
+    const onDelete = () => {
+        if (!store) return;
+        showConfirmDialog({
+            title: translations.FEED_DELETE_POST_TITLE || translations.DELETE || 'Delete post',
+            message: translations.FEED_DELETE_POST_CONFIRM || 'Delete this post?',
+            confirmText: translations.DELETE || 'Delete',
+            cancelText: translations.CANCEL || translations.DISMISS || 'Cancel',
+            destructive: true,
+            onConfirm: () => void deleteFeedPost(store, post.id),
+            onCancel: () => undefined,
+        });
+    };
+
     return (
-        <View
-            testID={`feedPostRow-${post.id}`}
-            accessibilityLabel={`feedPostRow-${post.id}`}
-            style={styles.feed?.post}
-        >
-            <View style={styles.feed?.postHeader}>
-                {author ? <Text style={styles.feed?.postAuthor}>{author}</Text> : null}
+        <View testID={`feedPostRow-${post.id}`} accessibilityLabel={`feedPostRow-${post.id}`} style={f?.post}>
+            <View style={f?.postHeader}>
+                {avatarSource ? <Image style={f?.postAvatar} source={avatarSource} /> : null}
+                <View style={f?.postHeaderText}>
+                    {author ? <Text style={f?.postAuthor}>{author}</Text> : null}
+                    {date ? <Text style={f?.postDate}>{date}</Text> : null}
+                </View>
                 {showFollowPill && followStateProvider !== undefined && post.fromUserId !== undefined ? (
                     <FeedFollowPill
                         provider={followStateProvider}
@@ -104,36 +139,96 @@ function FeedPostRowImpl({ post, translations, styles, customToolbarButtons, sto
                         styles={styles}
                     />
                 ) : null}
+                {canDelete ? (
+                    <TouchableOpacity
+                        testID={`feedPostMenu-${post.id}`}
+                        accessibilityLabel="feedPostMenu"
+                        style={f?.postMenuButton}
+                        onPress={onDelete}
+                    >
+                        <View style={f?.postMenuDot} />
+                        <View style={f?.postMenuDot} />
+                        <View style={f?.postMenuDot} />
+                    </TouchableOpacity>
+                ) : null}
             </View>
-            {post.title ? <Text style={styles.feed?.postTitle}>{post.title}</Text> : null}
-            {content ? <Text style={styles.feed?.postContent}>{content}</Text> : null}
+
+            {post.title ? <Text style={f?.postTitle}>{post.title}</Text> : null}
+            {contentHTML && stripHtml(contentHTML) ? (
+                <RenderHtml source={{ html: contentHTML }} contentWidth={Math.max(0, width - 32)} baseStyle={f?.postContent as MixedStyleDeclaration | undefined} />
+            ) : null}
+
             {post.media && post.media.length > 0 ? (
                 <FeedPostMediaGallery postId={post.id} media={post.media} styles={styles} />
             ) : null}
-            {date ? <Text style={styles.feed?.postDate}>{date}</Text> : null}
+
             {store ? (
-                <FeedPostReactions
-                    post={post}
-                    store={store}
-                    translations={translations}
-                    styles={styles}
-                />
+                <FeedPostReactions post={post} store={store} translations={translations} styles={styles} />
             ) : null}
+
+            {store ? (
+                <View style={f?.postActions}>
+                    <TouchableOpacity
+                        testID={`feedPostCommentButton-${post.id}`}
+                        accessibilityLabel="feedPostCommentButton"
+                        style={f?.postActionButton}
+                        onPress={() => setCommentsOpen(true)}
+                    >
+                        <Text style={f?.postActionLabel}>
+                            {(translations.FEED_COMMENTS || 'Comments')}
+                            {typeof post.commentCount === 'number' && post.commentCount > 0 ? ` (${post.commentCount})` : ''}
+                        </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        testID={`feedPostShareButton-${post.id}`}
+                        accessibilityLabel="feedPostShareButton"
+                        style={f?.postActionButton}
+                        onPress={() => void sharePost(post)}
+                    >
+                        <Text style={f?.postActionLabel}>{translations.FEED_SHARE || 'Share'}</Text>
+                    </TouchableOpacity>
+                </View>
+            ) : null}
+
             {visibleButtons.length > 0 ? (
-                <View
-                    testID={`feedCustomToolbar-${post.id}`}
-                    accessibilityLabel={`feedCustomToolbar-${post.id}`}
-                    style={styles.feed?.customToolbar}
-                >
+                <View testID={`feedCustomToolbar-${post.id}`} accessibilityLabel={`feedCustomToolbar-${post.id}`} style={f?.customToolbar}>
                     {visibleButtons.map((button) => (
-                        <FeedCustomToolbarButtonView
-                            key={button.id}
-                            button={button}
-                            post={post}
-                            styles={styles}
-                        />
+                        <FeedCustomToolbarButtonView key={button.id} button={button} post={post} styles={styles} />
                     ))}
                 </View>
+            ) : null}
+
+            {commentsConfig ? (
+                <Modal visible={commentsOpen} animationType="slide" transparent onRequestClose={() => setCommentsOpen(false)}>
+                    <View style={f?.commentsModalScrim}>
+                        <View style={f?.commentsModalSheet}>
+                            <View style={f?.commentsModalHeader}>
+                                <Text style={f?.commentsModalTitle}>
+                                    {post.title || translations.FEED_COMMENTS || 'Comments'}
+                                </Text>
+                                <TouchableOpacity
+                                    testID={`feedPostCommentsClose-${post.id}`}
+                                    accessibilityLabel="feedPostCommentsClose"
+                                    onPress={() => setCommentsOpen(false)}
+                                >
+                                    <Image
+                                        source={
+                                            imageAssets?.[
+                                                feedConfig?.hasDarkBackground
+                                                    ? FastCommentsImageAsset.ICON_CROSS_WHITE
+                                                    : FastCommentsImageAsset.ICON_CROSS
+                                            ]
+                                        }
+                                        style={f?.commentsModalCloseIcon}
+                                    />
+                                </TouchableOpacity>
+                            </View>
+                            {commentsOpen ? (
+                                <FastCommentsLiveCommenting config={commentsConfig} styles={styles} callbacks={callbacks} />
+                            ) : null}
+                        </View>
+                    </View>
+                </Modal>
             ) : null}
         </View>
     );
@@ -142,8 +237,5 @@ function FeedPostRowImpl({ post, translations, styles, customToolbarButtons, sto
 /**
  * Wrapped in `memo` so a state mutation that re-renders the parent feed
  * (reaction tick, stats merge, banner counter) doesn't re-render every row.
- * Inputs are referentially stable: each `post` is replaced in `feedPostsById`
- * only when its own fields change, and `translations`/`styles`/`store`/etc.
- * are stable across renders.
  */
 export const FeedPostRow = memo(FeedPostRowImpl);

--- a/src/components/feed-post-row.tsx
+++ b/src/components/feed-post-row.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, useState } from 'react';
-import { Image, Modal, Share, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+import { Image, Linking, Modal, Share, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import RenderHtml, { type MixedStyleDeclaration } from 'react-native-render-html';
 import type { FeedPost } from '../types/feed-post';
 import type { FeedCustomToolbarButton } from '../types/feed-custom-toolbar-button';
@@ -160,6 +160,24 @@ function FeedPostRowImpl({ post, translations, styles, customToolbarButtons, sto
 
             {post.media && post.media.length > 0 ? (
                 <FeedPostMediaGallery postId={post.id} media={post.media} styles={styles} />
+            ) : null}
+
+            {post.links && post.links.length > 0 ? (
+                <View style={f?.postLinks}>
+                    {post.links.map((link, i) => (
+                        <TouchableOpacity
+                            key={`${link.url}-${i}`}
+                            testID={`feedPostLink-${post.id}-${i}`}
+                            accessibilityLabel="feedPostLink"
+                            style={f?.postLinkButton}
+                            onPress={() => link.url && void Linking.openURL(link.url)}
+                        >
+                            <Text style={f?.postLinkButtonText} numberOfLines={1}>
+                                {link.title || link.text || link.url}
+                            </Text>
+                        </TouchableOpacity>
+                    ))}
+                </View>
             ) : null}
 
             {store ? (

--- a/src/components/feed.tsx
+++ b/src/components/feed.tsx
@@ -232,12 +232,13 @@ export const FastCommentsFeed = forwardRef<FastCommentsFeedHandle, FastCommentsF
                 styles={effectiveStyles}
                 customToolbarButtons={customToolbarButtons}
                 store={store}
+                callbacks={callbacks}
                 currentUser={currentUser}
                 followStateProvider={followStateProvider}
                 followStateRevision={followStateRevision}
             />
         ),
-        [translations, effectiveStyles, customToolbarButtons, store, currentUser, followStateProvider, followStateRevision]
+        [translations, effectiveStyles, customToolbarButtons, store, callbacks, currentUser, followStateProvider, followStateRevision]
     );
 
     const empty = (

--- a/src/components/feed.tsx
+++ b/src/components/feed.tsx
@@ -12,8 +12,7 @@ import { ListLoadingSkeleton, Skeleton } from './skeleton';
 import { resolveStyles } from '../resources/resolve-styles';
 import { isDarkColor, resolveTheme } from '../resources/themes';
 import { FastCommentsThemeOverrides } from '../types/fastcomments-theme';
-import { addTranslationsToStore } from '../services/translations';
-import { createFeedPost, loadFeedPosts } from '../services/feed';
+import { loadFeedPosts, setupFeedTranslations } from '../services/feed';
 import { teardownFeedLive } from '../services/feed-live';
 import {
     getFeedScrollOffset,
@@ -21,10 +20,10 @@ import {
 } from '../services/feed-scroll-memory';
 import { startFeedStatsPoll, stopFeedStatsPoll } from '../services/feed-stats';
 import { FeedNewPostsBanner } from './feed-new-posts-banner';
-import { FeedPostComposer } from './feed-post-composer';
+import { FastCommentsFeedPostCreate } from './feed-post-create';
 import { FeedPostRow } from './feed-post-row';
 import type { FastCommentsRNConfig } from '../types/react-native-config';
-import type { CreateFeedPostParams, FeedPost } from '../types/feed-post';
+import type { FeedPost } from '../types/feed-post';
 import type { FeedCustomToolbarButton } from '../types/feed-custom-toolbar-button';
 import type { FollowStateProvider } from '../types/follow-state-provider';
 import type {
@@ -113,36 +112,10 @@ export const FastCommentsFeed = forwardRef<FastCommentsFeedHandle, FastCommentsF
         let cancelled = false;
         async function init() {
             setIsLoading(true);
-            // Translations: pull the comment-ui set once on mount. The Feed
-            // is rendered standalone so it doesn't piggyback on the comments
-            // GET. We don't fail the feed load if this errors - the feed
-            // simply renders with empty translation strings.
-            // comment-ui supplies shared keys (date phrasing for getPrettyDate,
-            // common error messages); feed-ui supplies feed-specific copy.
-            // allSettled so a missing namespace (e.g. server doesn't have the
-            // file yet) doesn't drop the other one.
-            const sdk = store.getState().sdk;
-            const results = await Promise.allSettled([
-                sdk.publicApi.getTranslations({
-                    namespace: 'widgets',
-                    component: 'comment-ui',
-                    useFullTranslationIds: true,
-                    locale: config.locale,
-                }),
-                sdk.publicApi.getTranslations({
-                    namespace: 'widgets',
-                    component: 'feed-ui',
-                    useFullTranslationIds: true,
-                    locale: config.locale,
-                }),
-            ]);
-            if (!cancelled) {
-                for (const r of results) {
-                    if (r.status === 'fulfilled' && r.value.translations) {
-                        addTranslationsToStore(store, r.value.translations);
-                    }
-                }
-            }
+            // Translations: pull the feed's UI copy once on mount (comment-ui +
+            // feed-ui). The Feed is standalone so it doesn't piggyback on the
+            // comments GET; failures just render empty strings.
+            await setupFeedTranslations(store, config.locale);
 
             await loadFeedPosts(store);
             if (!cancelled) {
@@ -234,10 +207,6 @@ export const FastCommentsFeed = forwardRef<FastCommentsFeedHandle, FastCommentsF
         });
     };
 
-    const onSubmit = async (params: CreateFeedPostParams) => {
-        await createFeedPost(store, params);
-    };
-
     const onEndReached = async () => {
         if (isPaging || !feedHasMore || !feedAfterId) return;
         setIsPaging(true);
@@ -322,13 +291,23 @@ export const FastCommentsFeed = forwardRef<FastCommentsFeedHandle, FastCommentsF
                     isPaging ? <Skeleton style={{ height: 40, marginVertical: 8, marginHorizontal: 16 }} /> : null
                 }
             />
-            <FeedPostComposer
-                translations={translations}
-                styles={effectiveStyles}
-                submit={onSubmit}
-                store={store}
-                pickImage={callbacks?.pickImage}
-            />
+            {!config.hideFeedComposer && (
+                <FastCommentsFeedPostCreate
+                    store={store}
+                    styles={effectiveStyles}
+                    pickImage={callbacks?.pickImage}
+                    pickGIF={callbacks?.pickGIF}
+                    onError={callbacks?.onError}
+                    onPostCreated={() => {
+                        // Jump to the top so the new post (prepended) is visible.
+                        try {
+                            listRef.current?.scrollToOffset({ offset: 0, animated: true });
+                        } catch (e) {
+                            // ignore - jest's FlatList mock may not implement scrollToOffset.
+                        }
+                    }}
+                />
+            )}
         </View>
     );
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export * from './feed-custom-toolbar-button';
 export * from './feed-follow-pill';
 export * from './feed-new-posts-banner';
 export * from './feed-post-composer';
+export * from './feed-post-create';
 export * from './feed-post-media-attach';
 export * from './feed-post-media-gallery';
 export * from './feed-post-reactions';

--- a/src/components/live-chat.tsx
+++ b/src/components/live-chat.tsx
@@ -4,6 +4,7 @@ import { FastCommentsRNConfig } from '../types/react-native-config';
 import { buildChatConfig } from '../services/chat-config';
 import { FastCommentsThemeOverrides } from '../types/fastcomments-theme';
 import { FastCommentsCallbacks, IFastCommentsStyles, ImageAssetConfig } from '../types';
+import type { FastCommentsStore } from '../store/types';
 
 export interface FastCommentsLiveChatProps {
     config: FastCommentsRNConfig;
@@ -13,6 +14,12 @@ export interface FastCommentsLiveChatProps {
     styles?: IFastCommentsStyles;
     callbacks?: FastCommentsCallbacks;
     assets?: ImageAssetConfig;
+    /**
+     * Called once with the internal store after it is created. Use it to render
+     * store-driven widgets (e.g. OnlineUsersList) next to the chat against the
+     * same live state.
+     */
+    onStoreReady?: (store: FastCommentsStore) => void;
 }
 
 /**
@@ -22,7 +29,7 @@ export interface FastCommentsLiveChatProps {
  * infinite history instead of pagination buttons, flat (no replies), no votes.
  * Any of these presets can be overridden via `config`.
  */
-export function FastCommentsLiveChat({ config, theme, styles, callbacks, assets }: FastCommentsLiveChatProps) {
+export function FastCommentsLiveChat({ config, theme, styles, callbacks, assets, onStoreReady }: FastCommentsLiveChatProps) {
     const chatConfig = useMemo<FastCommentsRNConfig>(() => buildChatConfig(config), [config]);
     return (
         <FastCommentsLiveCommenting
@@ -31,6 +38,7 @@ export function FastCommentsLiveChat({ config, theme, styles, callbacks, assets 
             styles={styles}
             callbacks={callbacks}
             assets={assets}
+            onStoreReady={onStoreReady}
         />
     );
 }

--- a/src/components/live-commenting.tsx
+++ b/src/components/live-commenting.tsx
@@ -33,9 +33,15 @@ export interface FastCommentsLiveCommentingProps {
     styles?: IFastCommentsStyles;
     callbacks?: FastCommentsCallbacks;
     assets?: ImageAssetConfig;
+    /**
+     * Called once with the internal store after it is created. Use it to render
+     * store-driven widgets (e.g. OnlineUsersList / OnlineUsersFacepile) alongside
+     * the widget against the same live state.
+     */
+    onStoreReady?: (store: FastCommentsStore) => void;
 }
 
-export function FastCommentsLiveCommenting({ config, theme, styles: stylesProp, callbacks, assets }: FastCommentsLiveCommentingProps) {
+export function FastCommentsLiveCommenting({ config, theme, styles: stylesProp, callbacks, assets, onStoreReady }: FastCommentsLiveCommentingProps) {
     const styles = useMemo(() => resolveStyles(stylesProp, theme), [stylesProp, theme]);
 
     const storeRef = useRef<FastCommentsStore | null>(null);
@@ -47,6 +53,13 @@ export function FastCommentsLiveCommenting({ config, theme, styles: stylesProp, 
         storeRef.current = FastCommentsLiveCommentingService.createStoreFromConfig({ ...config, hasDarkBackground }, assets);
     }
     const store = storeRef.current!;
+
+    // Hand the store to the host once (store identity is stable for this mount).
+    const onStoreReadyRef = useRef(onStoreReady);
+    onStoreReadyRef.current = onStoreReady;
+    useEffect(() => {
+        onStoreReadyRef.current?.(store);
+    }, [store]);
 
     const imageAssets = useStoreValue(store, (s) => s.imageAssets);
     const blockingErrorMessage = useStoreValue(store, (s) => s.blockingErrorMessage);

--- a/src/components/live-status-bar.tsx
+++ b/src/components/live-status-bar.tsx
@@ -1,5 +1,5 @@
 import { Text, View, Modal } from 'react-native';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IFastCommentsStyles } from '../types';
 import type { FastCommentsStore } from '../store/types';
 import { useStoreValue } from '../store/hooks';
@@ -12,41 +12,18 @@ export interface LiveStatusBarProps {
     styles: IFastCommentsStyles;
 }
 
-// Refresh the online-users list at most this often. Presence frames (p-u) can
-// arrive many times per second in a busy room; this caps the getOnlineUsers
-// network/render cost while still keeping the facepile reasonably fresh.
-const MIN_REFRESH_MS = 4000;
-
 export function LiveStatusBar({ store, styles }: LiveStatusBarProps) {
     const wsConnected = useStoreValue(store, (s) => s.wsConnected);
     const subscriberCount = useStoreValue(store, (s) => s.subscriberCount);
     const translations = useStoreValue(store, (s) => s.translations);
     const [listOpen, setListOpen] = useState(false);
 
-    // Keep the facepile/list fresh on join/leave (subscriberCount changes), but
-    // throttle to at most one fetch per MIN_REFRESH_MS. When a refresh is already
-    // pending we coalesce into it rather than resetting the timer - a pure
-    // trailing debounce would starve under continuous churn and never refresh
-    // until a quiet gap. The first change (incl. mount) fires immediately.
-    const lastLoadRef = useRef(0);
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Load the initial online-users snapshot once. Join/leave churn is then
+    // applied incrementally from presence frames (see applyOnlineUsersPresenceUpdate
+    // in live.ts) - no full re-fetch per change, matching the web widget.
     useEffect(() => {
-        if (timerRef.current) return; // already scheduled; let it fire
-        const wait = Math.max(0, MIN_REFRESH_MS - (Date.now() - lastLoadRef.current));
-        timerRef.current = setTimeout(() => {
-            timerRef.current = null;
-            lastLoadRef.current = Date.now();
-            void loadOnlineUsers(store);
-        }, wait);
-    }, [store, subscriberCount]);
-    // Clear any pending refresh on unmount only (not on every count change, which
-    // would defeat the throttle).
-    useEffect(
-        () => () => {
-            if (timerRef.current) clearTimeout(timerRef.current);
-        },
-        []
-    );
+        void loadOnlineUsers(store);
+    }, [store]);
 
     const statusText = wsConnected ? translations.LIVE : translations.DISCONNECTED;
     // Fall back to a plain string when the server did not send the live-chat

--- a/src/components/live-status-bar.tsx
+++ b/src/components/live-status-bar.tsx
@@ -5,7 +5,7 @@ import type { FastCommentsStore } from '../store/types';
 import { useStoreValue } from '../store/hooks';
 import { OnlineUsersFacepile } from './online-users-facepile';
 import { OnlineUsersList } from './online-users-list';
-import { loadOnlineUsers } from '../services/online-users';
+import { ensureOnlineUsersLoaded } from '../services/online-users';
 
 export interface LiveStatusBarProps {
     store: FastCommentsStore;
@@ -18,11 +18,11 @@ export function LiveStatusBar({ store, styles }: LiveStatusBarProps) {
     const translations = useStoreValue(store, (s) => s.translations);
     const [listOpen, setListOpen] = useState(false);
 
-    // Load the initial online-users snapshot once. Join/leave churn is then
-    // applied incrementally from presence frames (see applyOnlineUsersPresenceUpdate
-    // in live.ts) - no full re-fetch per change, matching the web widget.
+    // Load the initial online-users snapshot once (deduped across widgets). Join/
+    // leave churn is then applied incrementally from presence frames (see
+    // applyOnlineUsersPresenceUpdate in live.ts) - no full re-fetch per change.
     useEffect(() => {
-        void loadOnlineUsers(store);
+        ensureOnlineUsersLoaded(store);
     }, [store]);
 
     const statusText = wsConnected ? translations.LIVE : translations.DISCONNECTED;

--- a/src/components/online-users-facepile.tsx
+++ b/src/components/online-users-facepile.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react';
 import { View, Image, Text, TouchableOpacity } from 'react-native';
 import { IFastCommentsStyles } from '../types';
 import type { FastCommentsStore } from '../store/types';
 import { useStoreValue } from '../store/hooks';
 import { getDefaultAvatarSrc } from '../services/default-avatar';
+import { ensureOnlineUsersLoaded } from '../services/online-users';
 
 export interface OnlineUsersFacepileProps {
     store: FastCommentsStore;
@@ -18,6 +20,12 @@ export function OnlineUsersFacepile({ store, styles, onPress, max = 4 }: OnlineU
     const onlineUsers = useStoreValue(store, (s) => s.onlineUsers);
     const totalCount = useStoreValue(store, (s) => s.onlineUsersTotalCount);
     const imageAssets = useStoreValue(store, (s) => s.imageAssets);
+
+    // Self-load the snapshot so this works standalone (e.g. next to the chat
+    // with the header hidden); deduped if the header already loaded it.
+    useEffect(() => {
+        ensureOnlineUsersLoaded(store);
+    }, [store]);
 
     if (!onlineUsers.length) return null;
     const shown = onlineUsers.slice(0, max);

--- a/src/components/online-users-list.tsx
+++ b/src/components/online-users-list.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { View, Image, Text, TouchableOpacity, ScrollView } from 'react-native';
 import { FastCommentsImageAsset, IFastCommentsStyles } from '../types';
 import type { FastCommentsStore } from '../store/types';
+import type { OnlineUser } from '../types/fastcomments-state';
 import { useStoreValue } from '../store/hooks';
 import { getDefaultAvatarSrc } from '../services/default-avatar';
-import { ensureOnlineUsersLoaded } from '../services/online-users';
+import { ensureOnlineUsersLoaded, loadOfflineUsers } from '../services/online-users';
 
 export interface OnlineUsersListProps {
     store: FastCommentsStore;
@@ -16,10 +17,15 @@ export interface OnlineUsersListProps {
      * the chat.
      */
     fill?: boolean;
+    /**
+     * Also show an "Offline" section (loaded via getOfflineUsers, paged with a
+     * "Load more" button), mirroring the web panel's `usersListIncludeOffline`.
+     */
+    showOffline?: boolean;
 }
 
-/** A panel listing the page's online users (avatar + name + presence dot). */
-export function OnlineUsersList({ store, styles, onClose, fill }: OnlineUsersListProps) {
+/** A panel listing the page's online (and optionally offline) users. */
+export function OnlineUsersList({ store, styles, onClose, fill, showOffline }: OnlineUsersListProps) {
     const onlineUsers = useStoreValue(store, (s) => s.onlineUsers);
     const totalCount = useStoreValue(store, (s) => s.onlineUsersTotalCount);
     const anonCount = useStoreValue(store, (s) => s.onlineUsersAnonCount);
@@ -33,12 +39,56 @@ export function OnlineUsersList({ store, styles, onClose, fill }: OnlineUsersLis
         ensureOnlineUsersLoaded(store);
     }, [store]);
 
+    // Offline users aren't presence-driven, so the panel owns their paginated
+    // list. `offlineNext` is null until the first page loads; its afterName drives
+    // whether a "Load more" remains.
+    const [offlineUsers, setOfflineUsers] = useState<OnlineUser[]>([]);
+    const [offlineNext, setOfflineNext] = useState<{ afterUserId: string | null; afterName: string | null } | null>(null);
+    const [offlineLoading, setOfflineLoading] = useState(false);
+
+    const fetchOffline = async (append: boolean) => {
+        if (offlineLoading) return;
+        setOfflineLoading(true);
+        const res = await loadOfflineUsers(
+            store,
+            append && offlineNext
+                ? { afterUserId: offlineNext.afterUserId ?? undefined, afterName: offlineNext.afterName ?? undefined }
+                : undefined
+        );
+        setOfflineLoading(false);
+        if (!res) return;
+        setOfflineUsers((prev) => (append ? [...prev, ...res.users] : res.users));
+        setOfflineNext({ afterUserId: res.nextAfterUserId, afterName: res.nextAfterName });
+    };
+
+    useEffect(() => {
+        if (!showOffline || offlineNext !== null) return; // load the first page once
+        void fetchOffline(false);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showOffline, store]);
+
     const ou = styles.onlineUsers;
     // Named users we did not load (large rooms) + anonymous users (never named).
     const remaining = Math.max(0, totalCount - onlineUsers.length - anonCount) + anonCount;
     // Singular vs plural, so a lone viewer reads "1 User Online", not "1 users online".
     const countTemplate = (totalCount === 1 ? translations.USER_ONLINE : translations.USERS_ONLINE) || `[count] Online`;
     const title = countTemplate.replace('[count]', String(totalCount));
+    const onlineLabel = translations.ONLINE_USERS_SECTION_ONLINE || 'Online';
+    const offlineLabel = translations.ONLINE_USERS_SECTION_OFFLINE || 'Offline';
+    const loadMoreLabel = translations.ONLINE_USERS_LOAD_MORE || 'Load more';
+
+    const renderRow = (u: OnlineUser, offline: boolean) => (
+        <View key={`${offline ? 'off' : 'on'}-${u.id}`} style={ou?.row}>
+            <Image
+                source={u.avatarSrc ? { uri: u.avatarSrc } : getDefaultAvatarSrc(imageAssets)}
+                style={ou?.rowAvatar}
+            />
+            <Text style={ou?.rowName} numberOfLines={1}>{u.displayName}</Text>
+            <View style={offline ? ou?.rowDotOffline : ou?.rowDot} />
+        </View>
+    );
+
+    const hasMoreOffline = !!offlineNext && offlineNext.afterName !== null;
 
     return (
         <View style={fill ? ou?.panelFill : ou?.panel} testID="onlineUsersList" accessibilityLabel="onlineUsersList">
@@ -54,20 +104,30 @@ export function OnlineUsersList({ store, styles, onClose, fill }: OnlineUsersLis
                 )}
             </View>
             <ScrollView style={[ou?.panelScroll, fill ? { flex: 1, minHeight: 0 } : null]}>
-                {onlineUsers.map((u) => (
-                    <View key={u.id} style={ou?.row}>
-                        <Image
-                            source={u.avatarSrc ? { uri: u.avatarSrc } : getDefaultAvatarSrc(imageAssets)}
-                            style={ou?.rowAvatar}
-                        />
-                        <Text style={ou?.rowName} numberOfLines={1}>{u.displayName}</Text>
-                        <View style={ou?.rowDot} />
-                    </View>
-                ))}
+                {showOffline && <Text style={[ou?.subheader, ou?.subheaderFirst]}>{onlineLabel}</Text>}
+                {onlineUsers.map((u) => renderRow(u, false))}
                 {remaining > 0 && (
                     <Text style={ou?.moreText}>
                         {(translations.AND_N_MORE_ONLINE || '+[count] more online').replace('[count]', String(remaining))}
                     </Text>
+                )}
+
+                {showOffline && offlineUsers.length > 0 && (
+                    <>
+                        <Text style={ou?.subheader}>{offlineLabel}</Text>
+                        {offlineUsers.map((u) => renderRow(u, true))}
+                        {hasMoreOffline && (
+                            <TouchableOpacity
+                                style={ou?.loadMore}
+                                disabled={offlineLoading}
+                                onPress={() => void fetchOffline(true)}
+                                testID="onlineUsersLoadMoreOffline"
+                                accessibilityLabel="onlineUsersLoadMoreOffline"
+                            >
+                                <Text style={ou?.loadMoreText}>{loadMoreLabel}</Text>
+                            </TouchableOpacity>
+                        )}
+                    </>
                 )}
             </ScrollView>
         </View>

--- a/src/components/online-users-list.tsx
+++ b/src/components/online-users-list.tsx
@@ -10,10 +10,16 @@ export interface OnlineUsersListProps {
     store: FastCommentsStore;
     styles: IFastCommentsStyles;
     onClose?: () => void;
+    /**
+     * Fill the parent container (a flex column, like the web sidebar) instead of
+     * the default centered modal card. Use when rendering as a sidebar next to
+     * the chat.
+     */
+    fill?: boolean;
 }
 
 /** A panel listing the page's online users (avatar + name + presence dot). */
-export function OnlineUsersList({ store, styles, onClose }: OnlineUsersListProps) {
+export function OnlineUsersList({ store, styles, onClose, fill }: OnlineUsersListProps) {
     const onlineUsers = useStoreValue(store, (s) => s.onlineUsers);
     const totalCount = useStoreValue(store, (s) => s.onlineUsersTotalCount);
     const anonCount = useStoreValue(store, (s) => s.onlineUsersAnonCount);
@@ -30,11 +36,14 @@ export function OnlineUsersList({ store, styles, onClose }: OnlineUsersListProps
     const ou = styles.onlineUsers;
     // Named users we did not load (large rooms) + anonymous users (never named).
     const remaining = Math.max(0, totalCount - onlineUsers.length - anonCount) + anonCount;
+    // Singular vs plural, so a lone viewer reads "1 User Online", not "1 users online".
+    const countTemplate = (totalCount === 1 ? translations.USER_ONLINE : translations.USERS_ONLINE) || `[count] Online`;
+    const title = countTemplate.replace('[count]', String(totalCount));
 
     return (
-        <View style={ou?.panel} testID="onlineUsersList" accessibilityLabel="onlineUsersList">
+        <View style={fill ? ou?.panelFill : ou?.panel} testID="onlineUsersList" accessibilityLabel="onlineUsersList">
             <View style={ou?.panelHeader}>
-                <Text style={ou?.panelTitle}>{translations.USERS_ONLINE?.replace('[count]', String(totalCount)) || `${totalCount} Online`}</Text>
+                <Text style={ou?.panelTitle}>{title}</Text>
                 {onClose && (
                     <TouchableOpacity onPress={onClose} testID="onlineUsersListClose" accessibilityLabel="onlineUsersListClose">
                         <Image
@@ -44,7 +53,7 @@ export function OnlineUsersList({ store, styles, onClose }: OnlineUsersListProps
                     </TouchableOpacity>
                 )}
             </View>
-            <ScrollView style={ou?.panelScroll}>
+            <ScrollView style={[ou?.panelScroll, fill ? { flex: 1, minHeight: 0 } : null]}>
                 {onlineUsers.map((u) => (
                     <View key={u.id} style={ou?.row}>
                         <Image

--- a/src/components/online-users-list.tsx
+++ b/src/components/online-users-list.tsx
@@ -70,9 +70,6 @@ export function OnlineUsersList({ store, styles, onClose, fill, showOffline }: O
     const ou = styles.onlineUsers;
     // Named users we did not load (large rooms) + anonymous users (never named).
     const remaining = Math.max(0, totalCount - onlineUsers.length - anonCount) + anonCount;
-    // Singular vs plural, so a lone viewer reads "1 User Online", not "1 users online".
-    const countTemplate = (totalCount === 1 ? translations.USER_ONLINE : translations.USERS_ONLINE) || `[count] Online`;
-    const title = countTemplate.replace('[count]', String(totalCount));
     const onlineLabel = translations.ONLINE_USERS_SECTION_ONLINE || 'Online';
     const offlineLabel = translations.ONLINE_USERS_SECTION_OFFLINE || 'Offline';
     const loadMoreLabel = translations.ONLINE_USERS_LOAD_MORE || 'Load more';
@@ -92,19 +89,20 @@ export function OnlineUsersList({ store, styles, onClose, fill, showOffline }: O
 
     return (
         <View style={fill ? ou?.panelFill : ou?.panel} testID="onlineUsersList" accessibilityLabel="onlineUsersList">
-            <View style={ou?.panelHeader}>
-                <Text style={ou?.panelTitle}>{title}</Text>
-                {onClose && (
+            {/* No count title: the live-chat header already shows the online count,
+                and the section subheaders label the lists (matches the web panel). */}
+            {onClose && (
+                <View style={[ou?.panelHeader, { justifyContent: 'flex-end' }]}>
                     <TouchableOpacity onPress={onClose} testID="onlineUsersListClose" accessibilityLabel="onlineUsersListClose">
                         <Image
                             source={imageAssets[hasDarkBackground ? FastCommentsImageAsset.ICON_CROSS_WHITE : FastCommentsImageAsset.ICON_CROSS]}
                             style={ou?.panelCloseIcon}
                         />
                     </TouchableOpacity>
-                )}
-            </View>
+                </View>
+            )}
             <ScrollView style={[ou?.panelScroll, fill ? { flex: 1, minHeight: 0 } : null]}>
-                {showOffline && <Text style={[ou?.subheader, ou?.subheaderFirst]}>{onlineLabel}</Text>}
+                <Text style={[ou?.subheader, ou?.subheaderFirst]}>{onlineLabel}</Text>
                 {onlineUsers.map((u) => renderRow(u, false))}
                 {remaining > 0 && (
                     <Text style={ou?.moreText}>

--- a/src/components/online-users-list.tsx
+++ b/src/components/online-users-list.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react';
 import { View, Image, Text, TouchableOpacity, ScrollView } from 'react-native';
 import { FastCommentsImageAsset, IFastCommentsStyles } from '../types';
 import type { FastCommentsStore } from '../store/types';
 import { useStoreValue } from '../store/hooks';
 import { getDefaultAvatarSrc } from '../services/default-avatar';
+import { ensureOnlineUsersLoaded } from '../services/online-users';
 
 export interface OnlineUsersListProps {
     store: FastCommentsStore;
@@ -18,6 +20,12 @@ export function OnlineUsersList({ store, styles, onClose }: OnlineUsersListProps
     const imageAssets = useStoreValue(store, (s) => s.imageAssets);
     const translations = useStoreValue(store, (s) => s.translations);
     const hasDarkBackground = useStoreValue(store, (s) => !!s.config.hasDarkBackground);
+
+    // Self-load the snapshot so the list works standalone (e.g. as a sidebar
+    // next to the chat); deduped if another widget already loaded it.
+    useEffect(() => {
+        ensureOnlineUsersLoaded(store);
+    }, [store]);
 
     const ou = styles.onlineUsers;
     // Named users we did not load (large rooms) + anonymous users (never named).

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -233,6 +233,7 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 alignItems: 'center',
                 justifyContent: 'center'
             },
+            // Modal card (centered popover from the header facepile): sized + chrome.
             panel: {
                 width: 320,
                 maxWidth: '92%',
@@ -242,6 +243,17 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 paddingTop: t.spacing.md,
                 paddingBottom: t.spacing.md,
                 ...modalShadow
+            },
+            // Sidebar mode (`fill`): a flex column that fills its container, header
+            // fixed and the scroll area consuming the rest - mirrors the web widget's
+            // `.fc-online-users-panel` (display:flex; flex-direction:column).
+            panelFill: {
+                flex: 1,
+                alignSelf: 'stretch',
+                minHeight: 0,
+                backgroundColor: t.colors.surfaceRaised,
+                paddingTop: t.spacing.md,
+                paddingBottom: t.spacing.md,
             },
             panelHeader: {
                 flexDirection: 'row',

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -1805,6 +1805,121 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 borderTopColor: t.colors.border,
                 backgroundColor: t.colors.surface
             },
+            // Author header (avatar + name), mirroring Android's composer form header.
+            composerHeader: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginBottom: t.spacing.sm
+            },
+            composerAvatar: {
+                width: t.avatar.sm,
+                height: t.avatar.sm,
+                borderRadius: t.radius.pill,
+                marginRight: t.spacing.sm,
+                backgroundColor: t.colors.surfaceRaised
+            },
+            composerAuthorName: {
+                fontSize: t.fontSize.base,
+                fontWeight: t.fontWeight.semibold,
+                color: t.colors.textPrimary,
+                flex: 1
+            },
+            // Attached-link chips + the add-link input row.
+            composerLinkList: {
+                marginTop: t.spacing.sm
+            },
+            composerLinkPreview: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingVertical: t.spacing.xs,
+                paddingHorizontal: t.spacing.sm,
+                marginBottom: t.spacing.xs,
+                borderWidth: hairline,
+                borderColor: t.colors.border,
+                borderRadius: t.radius.sm,
+                backgroundColor: t.colors.inputBackground
+            },
+            composerLinkPreviewText: {
+                flex: 1,
+                fontSize: t.fontSize.base,
+                color: t.colors.link,
+                marginRight: t.spacing.sm
+            },
+            composerLinkRemove: {
+                fontSize: t.fontSize.base,
+                color: t.colors.textSecondary
+            },
+            composerLinkRow: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginTop: t.spacing.sm
+            },
+            composerLinkInput: {
+                flex: 1,
+                borderWidth: 1,
+                borderColor: t.colors.border,
+                borderRadius: t.radius.md,
+                padding: t.spacing.sm + 2,
+                fontSize: t.fontSize.base,
+                color: t.colors.textPrimary,
+                backgroundColor: t.colors.inputBackground
+            },
+            composerLinkAddButton: {
+                marginLeft: t.spacing.sm,
+                paddingVertical: t.spacing.sm,
+                paddingHorizontal: t.spacing.md,
+                borderRadius: t.radius.md,
+                backgroundColor: t.colors.surfaceRaised
+            },
+            composerLinkAddButtonText: {
+                fontSize: t.fontSize.base,
+                fontWeight: t.fontWeight.medium,
+                color: t.colors.textPrimary
+            },
+            // Composer action row: custom toolbar buttons + (add-link) trigger.
+            composerToolbar: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                marginTop: t.spacing.sm
+            },
+            composerToolbarButton: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingVertical: t.spacing.xs,
+                paddingHorizontal: t.spacing.sm,
+                marginRight: t.spacing.sm,
+                borderRadius: t.radius.sm,
+                backgroundColor: t.colors.surfaceRaised
+            },
+            composerToolbarButtonIcon: {
+                width: 18,
+                height: 18,
+                marginRight: t.spacing.xs
+            },
+            composerToolbarButtonLabel: {
+                fontSize: t.fontSize.base,
+                color: t.colors.textPrimary
+            },
+            // Footer: cancel + submit.
+            composerActions: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                marginTop: t.spacing.md
+            },
+            composerCancel: {
+                paddingVertical: t.spacing.sm,
+                paddingHorizontal: t.spacing.lg,
+                marginRight: t.spacing.sm,
+                borderRadius: t.radius.md
+            },
+            composerCancelText: {
+                fontSize: t.fontSize.base,
+                fontWeight: t.fontWeight.medium,
+                color: t.colors.textSecondary
+            },
             composerInputTitle: {
                 borderWidth: 1,
                 borderColor: t.colors.border,

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -2126,12 +2126,47 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 marginTop: t.spacing.xs + 2,
                 marginBottom: t.spacing.xs + 2
             },
+            // Dimensions are computed at render from the image aspect ratio +
+            // measured width (single = full width, multi = carousel page width).
             postMediaImage: {
-                width: 200,
-                height: 200,
-                marginRight: t.spacing.sm,
                 borderRadius: t.radius.md,
                 resizeMode: 'cover'
+            },
+            // Multi-image carousel page indicator.
+            postMediaDots: {
+                flexDirection: 'row',
+                justifyContent: 'center',
+                alignItems: 'center',
+                marginTop: t.spacing.xs
+            },
+            postMediaDot: {
+                width: 6,
+                height: 6,
+                borderRadius: t.radius.pill,
+                marginHorizontal: 3,
+                backgroundColor: t.colors.border
+            },
+            postMediaDotActive: {
+                backgroundColor: t.colors.primary
+            },
+            // TASK posts: action buttons rendered from the post's links.
+            postLinks: {
+                marginTop: t.spacing.sm
+            },
+            postLinkButton: {
+                paddingVertical: t.spacing.sm,
+                paddingHorizontal: t.spacing.md,
+                borderRadius: t.radius.md,
+                borderWidth: hairline,
+                borderColor: t.colors.border,
+                backgroundColor: t.colors.surfaceRaised,
+                marginBottom: t.spacing.xs,
+                alignItems: 'center'
+            },
+            postLinkButtonText: {
+                fontSize: t.fontSize.base,
+                fontWeight: t.fontWeight.medium,
+                color: t.colors.link
             },
             reactionsRow: {
                 flexDirection: 'row',

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -2132,18 +2132,47 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 borderRadius: t.radius.md,
                 resizeMode: 'cover'
             },
-            // Multi-image carousel page indicator.
+            // Multi-image carousel: relative wrapper for the overlaid nav arrows.
+            postMediaCarousel: {
+                position: 'relative'
+            },
+            postMediaNav: {
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                width: 44,
+                justifyContent: 'center',
+                alignItems: 'center',
+                zIndex: 2
+            },
+            postMediaNavButton: {
+                width: 32,
+                height: 32,
+                borderRadius: t.radius.pill,
+                backgroundColor: 'rgba(0,0,0,0.45)',
+                justifyContent: 'center',
+                alignItems: 'center'
+            },
+            postMediaNavText: {
+                color: '#FFFFFF',
+                fontSize: 22,
+                lineHeight: 24,
+                fontWeight: t.fontWeight.bold
+            },
+            // Page indicator dots (tappable).
             postMediaDots: {
                 flexDirection: 'row',
                 justifyContent: 'center',
                 alignItems: 'center',
                 marginTop: t.spacing.xs
             },
+            postMediaDotButton: {
+                padding: 4
+            },
             postMediaDot: {
                 width: 6,
                 height: 6,
                 borderRadius: t.radius.pill,
-                marginHorizontal: 3,
                 backgroundColor: t.colors.border
             },
             postMediaDotActive: {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -2154,21 +2154,24 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 alignItems: 'center'
             },
             // Chevron drawn from two borders (a View, not a glyph) so it sits dead
-            // center in the round button regardless of platform font metrics.
+            // center in the round button regardless of platform font metrics. The
+            // ink is biased toward the border corner, which lands ~1.8px above the
+            // box center after a 45deg rotation; the parent-frame translateY (last
+            // in the array -> applied after the rotate) pushes it back to center.
             postMediaChevron: {
                 width: 8,
                 height: 8,
                 borderColor: '#FFFFFF'
             },
             postMediaChevronPrev: {
-                borderBottomWidth: 2,
+                borderTopWidth: 2,
                 borderLeftWidth: 2,
-                transform: [{ rotate: '45deg' }, { translateX: 1 }]
+                transform: [{ translateY: 1.8 }, { rotate: '-45deg' }]
             },
             postMediaChevronNext: {
                 borderTopWidth: 2,
                 borderRightWidth: 2,
-                transform: [{ rotate: '45deg' }, { translateX: -1 }]
+                transform: [{ translateY: 1.8 }, { rotate: '45deg' }]
             },
             // Page indicator dots (tappable).
             postMediaDots: {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -1749,8 +1749,18 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
             postHeader: {
                 flexDirection: 'row',
                 alignItems: 'center',
-                justifyContent: 'space-between',
                 marginBottom: t.spacing.xs + 2
+            },
+            postAvatar: {
+                width: t.avatar.sm,
+                height: t.avatar.sm,
+                borderRadius: t.radius.pill,
+                marginRight: t.spacing.sm,
+                backgroundColor: t.colors.surfaceRaised
+            },
+            postHeaderText: {
+                flex: 1,
+                minWidth: 0
             },
             postTitle: {
                 fontSize: t.fontSize.lg,
@@ -1760,7 +1770,8 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
             },
             postAuthor: {
                 fontSize: t.fontSize.base,
-                color: t.colors.textSecondary,
+                fontWeight: t.fontWeight.semibold,
+                color: t.colors.textPrimary,
                 flexShrink: 1
             },
             followPill: {
@@ -1798,6 +1809,72 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
             postDate: {
                 fontSize: t.fontSize.base,
                 color: t.colors.textSecondary
+            },
+            // Three-dot post menu (delete on own posts).
+            postMenuButton: {
+                paddingVertical: t.spacing.xs,
+                paddingHorizontal: t.spacing.sm,
+                marginLeft: t.spacing.sm,
+                alignItems: 'center',
+                justifyContent: 'center'
+            },
+            postMenuDot: {
+                width: 4,
+                height: 4,
+                borderRadius: t.radius.pill,
+                marginVertical: 1.5,
+                backgroundColor: t.colors.textSecondary
+            },
+            // Comment + Share action row beneath the reactions.
+            postActions: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginTop: t.spacing.sm
+            },
+            postActionButton: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingVertical: t.spacing.xs,
+                paddingHorizontal: t.spacing.sm,
+                marginRight: t.spacing.md
+            },
+            postActionLabel: {
+                fontSize: t.fontSize.base,
+                fontWeight: t.fontWeight.medium,
+                color: t.colors.textSecondary
+            },
+            // Per-post comments modal (FastCommentsLiveCommenting for urlId post:<id>).
+            commentsModalScrim: {
+                flex: 1,
+                backgroundColor: '#00000066',
+                justifyContent: 'flex-end'
+            },
+            commentsModalSheet: {
+                maxHeight: '88%',
+                backgroundColor: t.colors.background,
+                borderTopLeftRadius: t.radius.lg,
+                borderTopRightRadius: t.radius.lg,
+                overflow: 'hidden'
+            },
+            commentsModalHeader: {
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingVertical: t.spacing.sm,
+                paddingHorizontal: t.spacing.md,
+                borderBottomWidth: hairline,
+                borderBottomColor: t.colors.border
+            },
+            commentsModalTitle: {
+                flex: 1,
+                fontSize: t.fontSize.lg,
+                fontWeight: t.fontWeight.semibold,
+                color: t.colors.textPrimary,
+                marginRight: t.spacing.sm
+            },
+            commentsModalCloseIcon: {
+                width: 16,
+                height: 16
             },
             composer: {
                 padding: t.spacing.md,

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -2153,11 +2153,22 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 justifyContent: 'center',
                 alignItems: 'center'
             },
-            postMediaNavText: {
-                color: '#FFFFFF',
-                fontSize: 22,
-                lineHeight: 24,
-                fontWeight: t.fontWeight.bold
+            // Chevron drawn from two borders (a View, not a glyph) so it sits dead
+            // center in the round button regardless of platform font metrics.
+            postMediaChevron: {
+                width: 8,
+                height: 8,
+                borderColor: '#FFFFFF'
+            },
+            postMediaChevronPrev: {
+                borderBottomWidth: 2,
+                borderLeftWidth: 2,
+                transform: [{ rotate: '45deg' }, { translateX: 1 }]
+            },
+            postMediaChevronNext: {
+                borderTopWidth: 2,
+                borderRightWidth: 2,
+                transform: [{ rotate: '45deg' }, { translateX: -1 }]
             },
             // Page indicator dots (tappable).
             postMediaDots: {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -2153,25 +2153,24 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 justifyContent: 'center',
                 alignItems: 'center'
             },
-            // Chevron drawn from two borders (a View, not a glyph) so it sits dead
-            // center in the round button regardless of platform font metrics. The
-            // ink is biased toward the border corner, which lands ~1.8px above the
-            // box center after a 45deg rotation; the parent-frame translateY (last
-            // in the array -> applied after the rotate) pushes it back to center.
+            // Caret drawn as a CSS-style triangle (a 0x0 View with colored borders),
+            // not a glyph - it's vertically symmetric, so it centers in the round
+            // button with no transform/font-metric fudging.
             postMediaChevron: {
-                width: 8,
-                height: 8,
-                borderColor: '#FFFFFF'
+                width: 0,
+                height: 0,
+                borderTopWidth: 5,
+                borderBottomWidth: 5,
+                borderTopColor: 'transparent',
+                borderBottomColor: 'transparent'
             },
             postMediaChevronPrev: {
-                borderTopWidth: 2,
-                borderLeftWidth: 2,
-                transform: [{ translateY: 1.8 }, { rotate: '-45deg' }]
+                borderRightWidth: 7,
+                borderRightColor: '#FFFFFF'
             },
             postMediaChevronNext: {
-                borderTopWidth: 2,
-                borderRightWidth: 2,
-                transform: [{ translateY: 1.8 }, { rotate: '45deg' }]
+                borderLeftWidth: 7,
+                borderLeftColor: '#FFFFFF'
             },
             // Page indicator dots (tappable).
             postMediaDots: {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -299,6 +299,44 @@ export function getDefaultFastCommentsStyles(theme?: FastCommentsTheme): IFastCo
                 borderRadius: t.radius.pill,
                 backgroundColor: t.colors.onlineIndicator
             },
+            // Offline presence dot: muted grey (web uses #c4c4c4).
+            rowDotOffline: {
+                width: 8,
+                height: 8,
+                borderRadius: t.radius.pill,
+                backgroundColor: t.colors.border
+            },
+            // Section subheaders ("Online" / "Offline") with a hairline divider above,
+            // matching the web panel's `.fc-ou-subheader`.
+            subheader: {
+                marginTop: t.spacing.md,
+                marginBottom: t.spacing.xs,
+                paddingTop: t.spacing.sm,
+                borderTopWidth: hairline,
+                borderColor: t.colors.border,
+                fontSize: t.fontSize.base,
+                fontWeight: t.fontWeight.medium,
+                color: t.colors.textSecondary
+            },
+            // The first subheader sits flush against the header - no divider/extra gap.
+            subheaderFirst: {
+                marginTop: t.spacing.xs,
+                paddingTop: 0,
+                borderTopWidth: 0
+            },
+            loadMore: {
+                marginTop: t.spacing.sm,
+                paddingTop: t.spacing.sm,
+                paddingBottom: t.spacing.sm,
+                borderWidth: hairline,
+                borderColor: t.colors.border,
+                borderRadius: t.radius.sm,
+                alignItems: 'center'
+            },
+            loadMoreText: {
+                fontSize: t.fontSize.base,
+                color: t.colors.textSecondary
+            },
             moreText: {
                 paddingTop: t.spacing.sm,
                 paddingBottom: t.spacing.sm,

--- a/src/services/__tests__/feed-post-comments-config.test.ts
+++ b/src/services/__tests__/feed-post-comments-config.test.ts
@@ -1,0 +1,42 @@
+import { buildPostCommentsConfig } from '../feed';
+import type { FastCommentsRNConfig } from '../../types/react-native-config';
+
+const feedConfig = {
+    tenantId: 'demo',
+    urlId: 'my-feed',
+    sso: 'sso-token',
+    region: 'us',
+} as unknown as FastCommentsRNConfig;
+
+describe('buildPostCommentsConfig', () => {
+    it('namespaces the urlId as post:<id> (matches the Android SDK)', () => {
+        const cfg = buildPostCommentsConfig({ id: 'abc123', title: 'Hi' }, feedConfig);
+        expect(cfg.urlId).toBe('post:abc123');
+    });
+
+    it('carries tenant + sso from the feed config', () => {
+        const cfg = buildPostCommentsConfig({ id: 'p1' }, feedConfig);
+        expect(cfg.tenantId).toBe('demo');
+        expect((cfg as { sso?: string }).sso).toBe('sso-token');
+        expect((cfg as { region?: string }).region).toBe('us');
+    });
+
+    it('uses the post title as the page title when present', () => {
+        const cfg = buildPostCommentsConfig({ id: 'p1', title: 'My Title' }, feedConfig);
+        expect(cfg.pageTitle).toBe('My Title');
+    });
+
+    it('falls back to a stripped, truncated content preview when there is no title', () => {
+        const long = '<p>' + 'word '.repeat(60).trim() + '</p>';
+        const cfg = buildPostCommentsConfig({ id: 'p1', contentHTML: long }, feedConfig);
+        expect(cfg.pageTitle).toBeDefined();
+        expect(cfg.pageTitle!.length).toBeLessThanOrEqual(100);
+        expect(cfg.pageTitle!.endsWith('…')).toBe(true);
+        expect(cfg.pageTitle).not.toContain('<');
+    });
+
+    it('leaves pageTitle undefined when there is no title or content', () => {
+        const cfg = buildPostCommentsConfig({ id: 'p1' }, feedConfig);
+        expect(cfg.pageTitle).toBeUndefined();
+    });
+});

--- a/src/services/__tests__/feed-post-type.test.ts
+++ b/src/services/__tests__/feed-post-type.test.ts
@@ -1,0 +1,27 @@
+import { getFeedPostType } from '../feed-post-type';
+import type { FeedPost } from '../../types/feed-post';
+
+const base = { id: 'p', tenantId: 't', createdAt: 0 } as FeedPost;
+const img = { sizes: [{ src: 'x', w: 10, h: 10 }] };
+
+describe('getFeedPostType', () => {
+    it('TEXT_ONLY when there is no media and no links', () => {
+        expect(getFeedPostType({ ...base })).toBe('TEXT_ONLY');
+    });
+
+    it('SINGLE_IMAGE for exactly one media item', () => {
+        expect(getFeedPostType({ ...base, media: [img] })).toBe('SINGLE_IMAGE');
+    });
+
+    it('MULTI_IMAGE for more than one media item', () => {
+        expect(getFeedPostType({ ...base, media: [img, img] })).toBe('MULTI_IMAGE');
+    });
+
+    it('TASK for a links-only post', () => {
+        expect(getFeedPostType({ ...base, links: [{ url: 'https://x' }] })).toBe('TASK');
+    });
+
+    it('media wins over links when both are present (image layout)', () => {
+        expect(getFeedPostType({ ...base, media: [img], links: [{ url: 'https://x' }] })).toBe('SINGLE_IMAGE');
+    });
+});

--- a/src/services/__tests__/online-users.test.ts
+++ b/src/services/__tests__/online-users.test.ts
@@ -1,0 +1,122 @@
+import { FastCommentsLiveCommentingService } from '../fastcomments-live-commenting';
+import { applyOnlineUsersPresenceUpdate } from '../online-users';
+
+// Drain the microtask queue so an awaited (already-resolved) mock + its
+// continuation run, without depending on jest.advanceTimersByTimeAsync.
+async function flushMicrotasks() {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+function makeStore() {
+    // Pass a stub imageAssets so the store factory skips getDefaultImageAssets()
+    // (which require()s .png files the jest unit env doesn't transform).
+    return FastCommentsLiveCommentingService.createStoreFromConfig(
+        { tenantId: 'demo', urlId: 'ou-unit', apiHost: 'https://fastcomments.com' } as any,
+        {} as any
+    );
+}
+
+describe('online-users incremental presence', () => {
+    it('store.applyOnlineUsersPresence adds named joins, drops leaves, tracks anon + total', () => {
+        const store = makeStore();
+        store.getState().setOnlineUsers([{ id: 'a', displayName: 'Alice' }], 1, 0);
+
+        store.getState().applyOnlineUsersPresence({ joinedNamed: ['b'], leftNamed: [], anonDelta: 2, totalCount: 5 });
+        let st = store.getState();
+        expect(st.onlineUsers.map((u) => u.id)).toEqual(['a', 'b']);
+        expect(st.onlineUsersAnonCount).toBe(2);
+        expect(st.onlineUsersTotalCount).toBe(5);
+
+        // A duplicate join is a no-op for the list.
+        store.getState().applyOnlineUsersPresence({ joinedNamed: ['b'], leftNamed: [], anonDelta: 0 });
+        expect(store.getState().onlineUsers.length).toBe(2);
+
+        // A leave drops the user; the anon count floors at 0.
+        store.getState().applyOnlineUsersPresence({ joinedNamed: [], leftNamed: ['a'], anonDelta: -5, totalCount: 1 });
+        st = store.getState();
+        expect(st.onlineUsers.map((u) => u.id)).toEqual(['b']);
+        expect(st.onlineUsersAnonCount).toBe(0);
+    });
+
+    it('store.upsertOnlineUsers fills placeholders but never adds new ids', () => {
+        const store = makeStore();
+        store.getState().setOnlineUsers([{ id: 'b', displayName: '' }], 1, 0);
+        store.getState().upsertOnlineUsers([
+            { id: 'b', displayName: 'Bob', avatarSrc: 'x' },
+            { id: 'ghost', displayName: 'Should not appear' },
+        ]);
+        expect(store.getState().onlineUsers).toEqual([{ id: 'b', displayName: 'Bob', avatarSrc: 'x' }]);
+    });
+
+    it('parses the anon: prefix and clamps the total to >= 1', () => {
+        const store = makeStore();
+        applyOnlineUsersPresenceUpdate(store, { uj: ['u1', 'anon:x', 'anon:y'], ul: [], sc: 3 });
+        const st = store.getState();
+        expect(st.onlineUsers.map((u) => u.id)).toEqual(['u1']);
+        expect(st.onlineUsersAnonCount).toBe(2);
+        expect(st.onlineUsersTotalCount).toBe(3);
+    });
+
+    it('enriches joined named users via a single debounced getUsersInfo call', async () => {
+        jest.useFakeTimers();
+        try {
+            const store = makeStore();
+            const getUsersInfo = jest.fn().mockResolvedValue({
+                status: 'success',
+                users: [
+                    { id: 'u1', displayName: 'User One', avatarSrc: 'a1' },
+                    { id: 'u2', displayName: 'User Two' },
+                ],
+            });
+            (store.getState().sdk.publicApi as any).getUsersInfo = getUsersInfo;
+
+            // Two joins in the same burst should coalesce into one request.
+            applyOnlineUsersPresenceUpdate(store, { uj: ['u1'], ul: [], sc: 1 });
+            applyOnlineUsersPresenceUpdate(store, { uj: ['u2'], ul: [], sc: 2 });
+
+            // Placeholders present immediately, names empty, before enrich fires.
+            expect(store.getState().onlineUsers).toEqual([
+                { id: 'u1', displayName: '' },
+                { id: 'u2', displayName: '' },
+            ]);
+            expect(getUsersInfo).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(500);
+            await flushMicrotasks();
+
+            expect(getUsersInfo).toHaveBeenCalledTimes(1);
+            expect(getUsersInfo).toHaveBeenCalledWith({ tenantId: 'demo', ids: 'u1,u2' });
+            expect(store.getState().onlineUsers).toEqual([
+                { id: 'u1', displayName: 'User One', avatarSrc: 'a1' },
+                { id: 'u2', displayName: 'User Two', avatarSrc: undefined },
+            ]);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('does not re-add a user who left before enrich completed', async () => {
+        jest.useFakeTimers();
+        try {
+            const store = makeStore();
+            const getUsersInfo = jest.fn().mockResolvedValue({
+                status: 'success',
+                users: [{ id: 'u1', displayName: 'User One' }],
+            });
+            (store.getState().sdk.publicApi as any).getUsersInfo = getUsersInfo;
+
+            applyOnlineUsersPresenceUpdate(store, { uj: ['u1'], ul: [], sc: 1 });
+            // u1 leaves before the debounce fires.
+            applyOnlineUsersPresenceUpdate(store, { uj: [], ul: ['u1'], sc: 0 });
+            expect(store.getState().onlineUsers).toEqual([]);
+
+            jest.advanceTimersByTime(500);
+            await flushMicrotasks();
+
+            // Even if the enrich response carries u1, it must not reappear.
+            expect(store.getState().onlineUsers).toEqual([]);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});

--- a/src/services/feed-post-type.ts
+++ b/src/services/feed-post-type.ts
@@ -1,0 +1,18 @@
+import type { FeedPost } from '../types/feed-post';
+
+/** The feed post layout kinds, mirroring the Android SDK's `FeedPostType`. */
+export type FeedPostType = 'TEXT_ONLY' | 'SINGLE_IMAGE' | 'MULTI_IMAGE' | 'TASK';
+
+/**
+ * Pick the layout for a post from its media + links, like Android's
+ * `FeedPostsAdapter`: a links-only post is a TASK (action buttons), otherwise
+ * the image count drives TEXT_ONLY / SINGLE_IMAGE / MULTI_IMAGE.
+ */
+export function getFeedPostType(post: Pick<FeedPost, 'media' | 'links'>): FeedPostType {
+    const mediaCount = post.media?.length ?? 0;
+    const hasLinks = !!post.links && post.links.length > 0;
+    if (mediaCount === 0 && hasLinks) return 'TASK';
+    if (mediaCount === 0) return 'TEXT_ONLY';
+    if (mediaCount === 1) return 'SINGLE_IMAGE';
+    return 'MULTI_IMAGE';
+}

--- a/src/services/feed.ts
+++ b/src/services/feed.ts
@@ -6,8 +6,29 @@ import type {
     FeedPostMediaItemAsset,
 } from '../types/feed-post';
 import type { FeedPost as SDKFeedPost } from 'fastcomments-sdk';
+import type { FastCommentsRNConfig } from '../types/react-native-config';
 import { newBroadcastId } from './broadcast-id';
 import { persistSubscriberState } from './live';
+import { addTranslationsToStore } from './translations';
+
+/**
+ * Load the feed's UI copy into the store: comment-ui (shared keys: date phrasing
+ * for getPrettyDate, common errors) + feed-ui (feed-specific). allSettled so a
+ * missing namespace doesn't drop the other; never throws (renders with empty
+ * strings on failure). Shared by FastCommentsFeed and the standalone composer.
+ */
+export async function setupFeedTranslations(store: FastCommentsStore, locale?: string): Promise<void> {
+    const sdk = store.getState().sdk;
+    const results = await Promise.allSettled([
+        sdk.publicApi.getTranslations({ namespace: 'widgets', component: 'comment-ui', useFullTranslationIds: true, locale }),
+        sdk.publicApi.getTranslations({ namespace: 'widgets', component: 'feed-ui', useFullTranslationIds: true, locale }),
+    ]);
+    for (const r of results) {
+        if (r.status === 'fulfilled' && r.value.translations) {
+            addTranslationsToStore(store, r.value.translations);
+        }
+    }
+}
 
 /**
  * The typed SDK already maps the wire `_id` to `id` and parses `createdAt` to
@@ -34,6 +55,7 @@ function toFeedPost(
         myReacts,
         commentCount: post.commentCount,
         media: post.media,
+        links: post.links,
     };
 }
 
@@ -50,6 +72,30 @@ function toFeedPosts(
         if (n) out.push(n);
     }
     return out;
+}
+
+/** Plain-text preview of HTML content, used as a comments page title. */
+function feedContentPreview(contentHTML: string | undefined): string {
+    if (!contentHTML) return '';
+    const text = contentHTML.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    return text.length > 100 ? `${text.slice(0, 97)}…` : text;
+}
+
+/**
+ * Build the comments-widget config for a single feed post. Mirrors the Android
+ * SDK's `createCommentsSDKForPost`: same tenant + SSO as the feed, the urlId
+ * namespaced as `post:<id>` (this is how a post's comment thread is associated),
+ * and a pageTitle from the post title or a content preview.
+ */
+export function buildPostCommentsConfig(
+    post: Pick<FeedPost, 'id' | 'title' | 'contentHTML'>,
+    feedConfig: FastCommentsRNConfig
+): FastCommentsRNConfig {
+    return {
+        ...feedConfig,
+        urlId: `post:${post.id}`,
+        pageTitle: post.title || feedContentPreview(post.contentHTML) || undefined,
+    };
 }
 
 interface FetchOptions {
@@ -158,6 +204,7 @@ export async function createFeedPost(
                 tags: params.tags,
                 meta: params.meta,
                 media: params.media,
+                links: params.links,
             },
         });
         if (response.status !== 'success' || !response.feedPost) {

--- a/src/services/live.ts
+++ b/src/services/live.ts
@@ -6,6 +6,7 @@ import { removeCommentOnClient } from './remove-comment-on-client';
 import { repositionComment } from './comment-positioning';
 import { incOverallCommentCount } from './comment-count';
 import { handleNewCustomConfig } from './custom-config';
+import { applyOnlineUsersPresenceUpdate } from './online-users';
 import type { FastCommentsStore } from '../store/types';
 
 const SubscriberInstanceById: Record<string, SubscriberInstance | void> = {};
@@ -38,6 +39,8 @@ export function handleLiveEvent(store: FastCommentsStore, dataJSON: WebsocketLiv
             break;
 
         case 'p-u': {
+            // Activity-dot presence map (keyed by raw id, incl. anon) + the
+            // status-bar subscriber count.
             if (dataJSON.uj && dataJSON.uj.length > 0) {
                 state.setUsersOnline(dataJSON.uj, true);
             }
@@ -47,6 +50,9 @@ export function handleLiveEvent(store: FastCommentsStore, dataJSON: WebsocketLiv
             if (typeof dataJSON.sc === 'number') {
                 state.setSubscriberCount(Math.max(dataJSON.sc, 1));
             }
+            // Incrementally update the online-users list/facepile (add/remove +
+            // debounced name/avatar enrich) instead of re-fetching the whole list.
+            applyOnlineUsersPresenceUpdate(store, { uj: dataJSON.uj, ul: dataJSON.ul, sc: dataJSON.sc });
             break;
         }
 

--- a/src/services/online-users.ts
+++ b/src/services/online-users.ts
@@ -65,6 +65,46 @@ export async function loadOnlineUsers(
     }
 }
 
+export interface LoadOfflineUsersResult {
+    users: OnlineUser[];
+    nextAfterUserId: string | null;
+    nextAfterName: string | null;
+}
+
+/**
+ * Load a page of the page's OFFLINE users (avatar + name), via the same
+ * getOfflineUsers endpoint the web widget's online-users panel uses for its
+ * "Offline" section. Offline users aren't presence-driven, so callers hold the
+ * accumulated list themselves and page with the returned nextAfter* cursor.
+ */
+export async function loadOfflineUsers(
+    store: FastCommentsStore,
+    opts?: { afterUserId?: string; afterName?: string }
+): Promise<LoadOfflineUsersResult | null> {
+    const state = store.getState();
+    const tenantId = state.config.tenantId;
+    const urlId = state.config.urlId;
+    if (!tenantId || !urlId) return null;
+    try {
+        const response = await state.sdk.publicApi.getOfflineUsers({
+            tenantId,
+            urlId,
+            afterUserId: opts?.afterUserId,
+            afterName: opts?.afterName,
+        });
+        if (response.status !== 'success') return null;
+        const latest = store.getState();
+        return {
+            users: (response.users || []).map((u) => toOnlineUser(u, latest.translations)),
+            nextAfterUserId: response.nextAfterUserId ?? null,
+            nextAfterName: response.nextAfterName ?? null,
+        };
+    } catch (e) {
+        console.error('Failed to load offline users', e);
+        return null;
+    }
+}
+
 // Ensure the initial online-users snapshot is loaded exactly once per store,
 // no matter how many online-users widgets mount (the in-header facepile and a
 // standalone side list can both call this; only the first actually fetches).

--- a/src/services/online-users.ts
+++ b/src/services/online-users.ts
@@ -65,6 +65,18 @@ export async function loadOnlineUsers(
     }
 }
 
+// Ensure the initial online-users snapshot is loaded exactly once per store,
+// no matter how many online-users widgets mount (the in-header facepile and a
+// standalone side list can both call this; only the first actually fetches).
+const initialLoadRequested = new WeakSet<FastCommentsStore>();
+export function ensureOnlineUsersLoaded(store: FastCommentsStore): void {
+    if (initialLoadRequested.has(store)) return;
+    initialLoadRequested.add(store);
+    // Already populated (header loaded it, or seeded by presence/tests)? Skip.
+    if (store.getState().onlineUsers.length > 0) return;
+    void loadOnlineUsers(store);
+}
+
 // Per-store enrich queue: a burst of joins is coalesced into one getUsersInfo
 // call. Scoped per store (WeakMap) so multiple widgets on a page don't collide.
 interface EnrichState {

--- a/src/services/online-users.ts
+++ b/src/services/online-users.ts
@@ -6,10 +6,34 @@ export interface LoadOnlineUsersResult {
     nextAfterName: string | null;
 }
 
+/** The page-user shape returned by getOnlineUsers / getUsersInfo. */
+interface PageUserEntryLike {
+    id: string;
+    displayName: string;
+    avatarSrc?: string | null;
+    isPrivate?: boolean;
+}
+
+// Presence frames tag anonymous users with an `anon:` id prefix; named users
+// carry their real userId. Match the web widget's online-users extension.
+const ANON_PREFIX = 'anon:';
+// Coalesce a burst of joins into one getUsersInfo call (matches the web widget).
+const ENRICH_DEBOUNCE_MS = 500;
+
+/** Map a server page-user to a store OnlineUser, masking private profiles. */
+function toOnlineUser(entry: PageUserEntryLike, translations: Record<string, string>): OnlineUser {
+    if (entry.isPrivate) {
+        return { id: entry.id, displayName: translations.PRIVATE_PROFILE || 'Private', avatarSrc: undefined };
+    }
+    return { id: entry.id, displayName: entry.displayName, avatarSrc: entry.avatarSrc ?? undefined };
+}
+
 /**
  * Load the page's online users (avatar + name) into the store for the live-chat
  * facepile / user list, via the same `getOnlineUsers` endpoint the web widget
- * uses. Pass `append` + the previous `nextAfter*` cursor to page through the list.
+ * uses. This is the initial snapshot + pagination; steady-state churn is applied
+ * incrementally via applyOnlineUsersPresenceUpdate (no full re-fetch per change).
+ * Pass `append` + the previous `nextAfter*` cursor to page through the list.
  */
 export async function loadOnlineUsers(
     store: FastCommentsStore,
@@ -27,12 +51,8 @@ export async function loadOnlineUsers(
             afterName: opts?.afterName,
         });
         if (response.status !== 'success') return null;
-        const mapped: OnlineUser[] = (response.users || []).map((u) => ({
-            id: u.id,
-            displayName: u.displayName,
-            avatarSrc: u.avatarSrc ?? undefined,
-        }));
         const latest = store.getState();
+        const mapped: OnlineUser[] = (response.users || []).map((u) => toOnlineUser(u, latest.translations));
         const users = opts?.append ? [...latest.onlineUsers, ...mapped] : mapped;
         latest.setOnlineUsers(users, response.totalCount ?? users.length, response.anonCount ?? 0);
         return {
@@ -43,4 +63,93 @@ export async function loadOnlineUsers(
         console.error('Failed to load online users', e);
         return null;
     }
+}
+
+// Per-store enrich queue: a burst of joins is coalesced into one getUsersInfo
+// call. Scoped per store (WeakMap) so multiple widgets on a page don't collide.
+interface EnrichState {
+    pending: Set<string>;
+    timer: ReturnType<typeof setTimeout> | null;
+}
+const enrichByStore = new WeakMap<FastCommentsStore, EnrichState>();
+
+function enrichStateFor(store: FastCommentsStore): EnrichState {
+    let s = enrichByStore.get(store);
+    if (!s) {
+        s = { pending: new Set(), timer: null };
+        enrichByStore.set(store, s);
+    }
+    return s;
+}
+
+function scheduleEnrich(store: FastCommentsStore, id: string) {
+    const s = enrichStateFor(store);
+    s.pending.add(id);
+    if (s.timer) return;
+    s.timer = setTimeout(() => {
+        s.timer = null;
+        void flushEnrich(store);
+    }, ENRICH_DEBOUNCE_MS);
+}
+
+async function flushEnrich(store: FastCommentsStore) {
+    const s = enrichStateFor(store);
+    const ids = [...s.pending];
+    s.pending.clear();
+    if (ids.length === 0) return;
+    const state = store.getState();
+    const tenantId = state.config.tenantId;
+    if (!tenantId) return;
+    try {
+        const response = await state.sdk.publicApi.getUsersInfo({ tenantId, ids: ids.join(',') });
+        if (response.status !== 'success' || !response.users) return;
+        const latest = store.getState();
+        // Only merge users still online (some may have left during the request);
+        // upsertOnlineUsers itself also refuses to add ids that aren't present.
+        const onlineIds = new Set(latest.onlineUsers.map((u) => u.id));
+        const enriched = response.users
+            .filter((u) => onlineIds.has(u.id))
+            .map((u) => toOnlineUser(u, latest.translations));
+        if (enriched.length > 0) latest.upsertOnlineUsers(enriched);
+    } catch {
+        // Swallow - presence events keep the list roughly correct regardless.
+    }
+}
+
+/**
+ * Apply a websocket presence frame (`p-u`) to the online-users list atomically:
+ * drop users who left, add placeholder rows for named users who joined (then
+ * enrich their name/avatar via a single debounced getUsersInfo), and adjust the
+ * anonymous + total counts. No full list re-fetch per change.
+ */
+export function applyOnlineUsersPresenceUpdate(
+    store: FastCommentsStore,
+    frame: { uj?: string[]; ul?: string[]; sc?: number }
+) {
+    const joinedNamed: string[] = [];
+    const leftNamed: string[] = [];
+    let anonDelta = 0;
+    for (const id of frame.uj || []) {
+        if (id.startsWith(ANON_PREFIX)) anonDelta++;
+        else joinedNamed.push(id);
+    }
+    for (const id of frame.ul || []) {
+        if (id.startsWith(ANON_PREFIX)) anonDelta--;
+        else leftNamed.push(id);
+    }
+    if (joinedNamed.length === 0 && leftNamed.length === 0 && anonDelta === 0 && typeof frame.sc !== 'number') {
+        return;
+    }
+    store.getState().applyOnlineUsersPresence({
+        joinedNamed,
+        leftNamed,
+        anonDelta,
+        totalCount: typeof frame.sc === 'number' ? Math.max(frame.sc, 1) : undefined,
+    });
+    // A user who just left no longer needs enriching; new joins do.
+    if (leftNamed.length > 0) {
+        const s = enrichStateFor(store);
+        for (const id of leftNamed) s.pending.delete(id);
+    }
+    for (const id of joinedNamed) scheduleEnrich(store, id);
 }

--- a/src/store/slices/presence.ts
+++ b/src/store/slices/presence.ts
@@ -23,6 +23,59 @@ export const createPresenceSlice: StateCreator<
     setOnlineUsers: (users, totalCount, anonCount) =>
         set({ onlineUsers: users, onlineUsersTotalCount: totalCount, onlineUsersAnonCount: anonCount }),
 
+    // Merge enriched fields into existing entries (by id). Never adds ids - a
+    // user who left mid-enrich must not reappear. Returns {} (no-op) when nothing
+    // changed, so unrelated selectors aren't disturbed.
+    upsertOnlineUsers: (incoming) =>
+        set((state) => {
+            const byId = new Map(state.onlineUsers.map((u) => [u.id, u]));
+            let changed = false;
+            for (const u of incoming) {
+                const prev = byId.get(u.id);
+                if (!prev) continue;
+                if (prev.displayName !== u.displayName || prev.avatarSrc !== u.avatarSrc) {
+                    byId.set(u.id, { ...prev, ...u });
+                    changed = true;
+                }
+            }
+            return changed ? { onlineUsers: [...byId.values()] } : {};
+        }),
+
+    removeOnlineUsers: (ids) =>
+        set((state) => {
+            if (ids.length === 0) return {};
+            const drop = new Set(ids);
+            const next = state.onlineUsers.filter((u) => !drop.has(u.id));
+            return next.length === state.onlineUsers.length ? {} : { onlineUsers: next };
+        }),
+
+    applyOnlineUsersPresence: ({ joinedNamed, leftNamed, anonDelta, totalCount }) =>
+        set((state) => {
+            let users = state.onlineUsers;
+            if (leftNamed.length > 0) {
+                const drop = new Set(leftNamed);
+                const filtered = users.filter((u) => !drop.has(u.id));
+                if (filtered.length !== users.length) users = filtered;
+            }
+            if (joinedNamed.length > 0) {
+                const existing = new Set(users.map((u) => u.id));
+                // Placeholder rows (empty name) until the getUsersInfo enrich fills
+                // them in, mirroring the web widget - the facepile updates at once.
+                const toAdd = joinedNamed
+                    .filter((id) => !existing.has(id))
+                    .map((id) => ({ id, displayName: '' }));
+                if (toAdd.length > 0) users = [...users, ...toAdd];
+            }
+            const patch: Partial<FastCommentsStoreState> = {};
+            if (users !== state.onlineUsers) patch.onlineUsers = users;
+            const anon = Math.max(0, state.onlineUsersAnonCount + anonDelta);
+            if (anon !== state.onlineUsersAnonCount) patch.onlineUsersAnonCount = anon;
+            if (totalCount !== undefined && totalCount !== state.onlineUsersTotalCount) {
+                patch.onlineUsersTotalCount = totalCount;
+            }
+            return patch;
+        }),
+
     setUsersOnline: (userIds, online) =>
         set((state) => {
             const usersOnlineMap = { ...state.userPresenceState.usersOnlineMap };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -113,6 +113,18 @@ export interface ConfigSlice {
     rememberBroadcastId: (id: string) => void;
 }
 
+/** A presence frame already split into named joins/leaves + an anon-count delta. */
+export interface OnlineUsersPresencePayload {
+    /** Named (non-anonymous) user ids that just joined. **/
+    joinedNamed: string[];
+    /** Named user ids that just left. **/
+    leftNamed: string[];
+    /** Net change to the anonymous-online count (+joins, -leaves). **/
+    anonDelta: number;
+    /** New total online count (the presence `sc`), if present in the frame. **/
+    totalCount?: number;
+}
+
 export interface PresenceSlice {
     userPresenceState: UserPresenceState;
     /**
@@ -135,7 +147,18 @@ export interface PresenceSlice {
     onlineUsersTotalCount: number;
     onlineUsersAnonCount: number;
 
+    /** Full replace - initial getOnlineUsers load and pagination append. **/
     setOnlineUsers: (users: OnlineUser[], totalCount: number, anonCount: number) => void;
+    /** Merge enriched name/avatar into existing online users (by id); never adds new ids. **/
+    upsertOnlineUsers: (users: OnlineUser[]) => void;
+    /** Remove online users by id (a presence leave). **/
+    removeOnlineUsers: (ids: string[]) => void;
+    /**
+     * Atomically apply a presence frame to the online-users list: add placeholder
+     * rows for joined named users, drop left users, adjust the anonymous count,
+     * and set the total - so a join/leave never re-fetches the whole list.
+     */
+    applyOnlineUsersPresence: (payload: OnlineUsersPresencePayload) => void;
     setUsersOnline: (userIds: string[], online: boolean) => void;
     replaceUsersOnlineMap: (map: Record<string, boolean>) => void;
     setUserIdsToCommentIds: (map: Record<string, string[]>) => void;

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -49,6 +49,14 @@ export interface IFastCommentsStyles {
         rowAvatar?: ImageStyle
         rowName?: TextStyle
         rowDot?: ViewStyle
+        /** Muted presence dot for offline users. **/
+        rowDotOffline?: ViewStyle
+        /** "Online" / "Offline" section subheaders. **/
+        subheader?: TextStyle
+        subheaderFirst?: TextStyle
+        /** "Load more" button for paging the offline list. **/
+        loadMore?: ViewStyle
+        loadMoreText?: TextStyle
         moreText?: TextStyle
     },
     bottomArea?: {

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -444,7 +444,9 @@ export interface IFastCommentsStyles {
         postMediaCarousel?: ViewStyle
         postMediaNav?: ViewStyle
         postMediaNavButton?: ViewStyle
-        postMediaNavText?: TextStyle
+        postMediaChevron?: ViewStyle
+        postMediaChevronPrev?: ViewStyle
+        postMediaChevronNext?: ViewStyle
         postMediaDots?: ViewStyle
         postMediaDotButton?: ViewStyle
         postMediaDot?: ViewStyle

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -378,10 +378,22 @@ export interface IFastCommentsStyles {
         newPostsBannerText?: TextStyle
         post?: ViewStyle
         postHeader?: ViewStyle
+        postAvatar?: ImageStyle
+        postHeaderText?: ViewStyle
         postTitle?: TextStyle
         postAuthor?: TextStyle
         postContent?: TextStyle
         postDate?: TextStyle
+        postMenuButton?: ViewStyle
+        postMenuDot?: ViewStyle
+        postActions?: ViewStyle
+        postActionButton?: ViewStyle
+        postActionLabel?: TextStyle
+        commentsModalScrim?: ViewStyle
+        commentsModalSheet?: ViewStyle
+        commentsModalHeader?: ViewStyle
+        commentsModalTitle?: TextStyle
+        commentsModalCloseIcon?: ImageStyle
         composer?: ViewStyle
         composerHeader?: ViewStyle
         composerAvatar?: ImageStyle

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -383,11 +383,29 @@ export interface IFastCommentsStyles {
         postContent?: TextStyle
         postDate?: TextStyle
         composer?: ViewStyle
+        composerHeader?: ViewStyle
+        composerAvatar?: ImageStyle
+        composerAuthorName?: TextStyle
         composerInputTitle?: TextStyle
         composerInput?: TextStyle
         composerSubmit?: ViewStyle
         composerSubmitText?: TextStyle
         composerSubmitDisabled?: ViewStyle
+        composerActions?: ViewStyle
+        composerCancel?: ViewStyle
+        composerCancelText?: TextStyle
+        composerLinkList?: ViewStyle
+        composerLinkPreview?: ViewStyle
+        composerLinkPreviewText?: TextStyle
+        composerLinkRemove?: TextStyle
+        composerLinkRow?: ViewStyle
+        composerLinkInput?: TextStyle
+        composerLinkAddButton?: ViewStyle
+        composerLinkAddButtonText?: TextStyle
+        composerToolbar?: ViewStyle
+        composerToolbarButton?: ViewStyle
+        composerToolbarButtonIcon?: ImageStyle
+        composerToolbarButtonLabel?: TextStyle
         customToolbar?: ViewStyle
         customToolbarButton?: ViewStyle
         customToolbarButtonIcon?: ImageStyle

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -39,6 +39,8 @@ export interface IFastCommentsStyles {
         faceOverflowText?: TextStyle
         modalScrim?: ViewStyle
         panel?: ViewStyle
+        /** Sidebar (fill) variant of the panel: fills its container as a flex column. **/
+        panelFill?: ViewStyle
         panelHeader?: ViewStyle
         panelTitle?: TextStyle
         panelCloseIcon?: ImageStyle

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -441,6 +441,12 @@ export interface IFastCommentsStyles {
         composerMediaToolbar?: ViewStyle
         postMediaGallery?: ViewStyle
         postMediaImage?: ImageStyle
+        postMediaDots?: ViewStyle
+        postMediaDot?: ViewStyle
+        postMediaDotActive?: ViewStyle
+        postLinks?: ViewStyle
+        postLinkButton?: ViewStyle
+        postLinkButtonText?: TextStyle
         reactionsRow?: ViewStyle
         reactionChip?: ViewStyle
         reactionChipActive?: ViewStyle

--- a/src/types/fastcomments-styles.ts
+++ b/src/types/fastcomments-styles.ts
@@ -441,7 +441,12 @@ export interface IFastCommentsStyles {
         composerMediaToolbar?: ViewStyle
         postMediaGallery?: ViewStyle
         postMediaImage?: ImageStyle
+        postMediaCarousel?: ViewStyle
+        postMediaNav?: ViewStyle
+        postMediaNavButton?: ViewStyle
+        postMediaNavText?: TextStyle
         postMediaDots?: ViewStyle
+        postMediaDotButton?: ViewStyle
         postMediaDot?: ViewStyle
         postMediaDotActive?: ViewStyle
         postLinks?: ViewStyle

--- a/src/types/feed-post.ts
+++ b/src/types/feed-post.ts
@@ -16,6 +16,18 @@ export interface FeedPostMediaItem {
     sizes: FeedPostMediaItemAsset[];
 }
 
+/**
+ * A link attached to a feed post. For TASK-style posts these render as action
+ * buttons (label from `text`/`title`, action = `url`); for link posts they show
+ * as a preview. Mirrors the SDK `FeedPostLink`.
+ */
+export interface FeedPostLink {
+    url?: string;
+    title?: string;
+    text?: string;
+    description?: string;
+}
+
 export interface FeedPost {
     id: string;
     tenantId: string;
@@ -37,6 +49,8 @@ export interface FeedPost {
     myReacts?: Record<string, boolean>;
     commentCount?: number | null;
     media?: FeedPostMediaItem[];
+    /** Attached links - rendered as a preview or as TASK action buttons. */
+    links?: FeedPostLink[];
 }
 
 export interface CreateFeedPostParams {
@@ -47,4 +61,5 @@ export interface CreateFeedPostParams {
     tags?: string[];
     meta?: Record<string, string>;
     media?: FeedPostMediaItem[];
+    links?: FeedPostLink[];
 }

--- a/src/types/react-native-config.ts
+++ b/src/types/react-native-config.ts
@@ -16,6 +16,8 @@ export interface FastCommentsRNConfig extends FastCommentsCommentWidgetConfig {
     showLiveStatus?: boolean
     /** When true (default), the FastCommentsFeed remembers its FlatList scroll offset across unmount/remount, keyed by tenantId + urlId. **/
     preserveFeedScrollPosition?: boolean
+    /** Hide the post composer built into FastCommentsFeed (e.g. when placing a standalone FastCommentsFeedPostCreate elsewhere). **/
+    hideFeedComposer?: boolean
     /** Render the submit button as an icon inside the comment box (replaces the standalone labeled button). **/
     useInlineSubmitButton?: boolean
     /** With useShowCommentsToggle: how many comments render above the Show Comments toggle while collapsed (mirrors the web widget's countAboveToggle). **/


### PR DESCRIPTION
Ships everything since `v5.0.1` as a minor release (`5.0.1` predates the merged-but-unreleased live-chat streaming work, so this bundles it with the new online-users and feed work).

## Live chat streaming UX
`FastCommentsLiveChat` matches the web live-chat widget: compact Twitch-style rows (small avatar + activity dot, bold name inlined with the message), day separators, no per-message dates/reply bar, red "Live" dot, composer divider, Ctrl/Cmd+Enter submit, in-place save shimmer (no spinner/flicker), reliable scroll-to-bottom.

## Online users
Red presence dot, always-on count, `OnlineUsersFacepile` + `OnlineUsersList` (Online/Offline sections via `getOfflineUsers`, `fill` sidebar mode). Presence is applied **incrementally** from websocket frames (add/remove + debounced `getUsersInfo` enrich) instead of a full re-fetch.

## Feed parity with the Android SDK
- **`FastCommentsFeedPostCreate`** - standalone composer (Android `FeedPostCreateView` equivalent): author header, rich enriched editor, media + link attachments, `tagSupplier`, custom toolbar buttons, cancel/loading/error. Store-shared (via `onStoreReady`) or self-managed (`config`).
- Post rows: author avatars, rich HTML content, comment button opening the post's comments (`urlId = "post:<id>"`, like Android), share, delete menu.
- Typed image layouts: single full-width, multi-image carousel (navigable), link-only -> action buttons.
- `config.hideFeedComposer`.

## Platform
- `onStoreReady(store)` on the chat/commenting/feed widgets + exported `FastCommentsStore` type, so hosts can render store-driven widgets alongside.
- Every spinner replaced with a shimmer (`Skeleton` / `ListLoadingSkeleton`) off one shared animation loop.
- Anchored popovers flip above the trigger when there's no room below.

## Tests
tsc clean; unit 170, web 18 - all green. Adds coverage for incremental presence, `buildPostCommentsConfig` (`post:<id>` urlId), feed post-type selection, `placeVertical` flip, and feed/online-users render tests.